### PR TITLE
fix: Oauth redirect not sending any session information

### DIFF
--- a/plugins/oauth2/handlers/callback_handler.go
+++ b/plugins/oauth2/handlers/callback_handler.go
@@ -137,14 +137,15 @@ func (h *CallbackHandler) Handler() http.HandlerFunc {
 			}
 		}
 
+		reqCtx.SetJSONResponse(http.StatusOK, &types.CallbackResponse{
+			User:    result.User,
+			Session: result.Session,
+			SessionToken: result.SessionToken,
+		})
+		
 		if redirectTo != "" {
 			http.Redirect(reqCtx.ResponseWriter, r, redirectTo, http.StatusFound)
 			return
 		}
-
-		reqCtx.SetJSONResponse(http.StatusOK, &types.CallbackResponse{
-			User:    result.User,
-			Session: result.Session,
-		})
 	}
 }


### PR DESCRIPTION
I propose this change due to the redirect not sending any information to the browser to handle the returned session.