### PR TITLE
fix: Custom route plugins not executing

### DIFF
--- a/router.go
+++ b/router.go
@@ -191,7 +191,6 @@ func (r *Router) SetRouteMetadataFromConfig(routeMetadata map[string]map[string]
 			r.routeMetadata[fullKey] = existing
 		} else {
 			r.routeMetadata[fullKey] = metadata
-
 			segments := strings.Split(strings.Trim(path, "/"), "/")
 			r.routeEntries = append(r.routeEntries, routeEntry{
 				Method:   method,


### PR DESCRIPTION
The issue was that that `routeMetadata` inside of `SetRouteMetadataFromConfig` was always being overridden with a fresh new map which meant that the metadata being passed in from `auth.go` after converting the metadata using utils was being wiped out completely.