### PR TITLE
fix: Issue with router redirect

### DIFF
--- a/models/context.go
+++ b/models/context.go
@@ -57,6 +57,10 @@ type RequestContext struct {
 	ResponseBody    []byte
 	ResponseReady   bool
 	ResponseData    any
+
+	// Redirect fields allow handlers to declare a redirect declaratively
+	// The router will perform the redirect after all HookAfter hooks run
+	RedirectURL string // URL to redirect to (empty = no redirect)
 }
 
 // NewContextWithRequestContext returns a new context with the RequestContext attached

--- a/plugins/oauth2/handlers/callback_handler.go
+++ b/plugins/oauth2/handlers/callback_handler.go
@@ -138,7 +138,9 @@ func (h *CallbackHandler) Handler() http.HandlerFunc {
 		}
 
 		if redirectTo != "" {
-			http.Redirect(reqCtx.ResponseWriter, r, redirectTo, http.StatusFound)
+			reqCtx.RedirectURL = redirectTo
+			reqCtx.ResponseStatus = http.StatusFound
+			reqCtx.Handled = true
 			return
 		}
 

--- a/router.go
+++ b/router.go
@@ -556,6 +556,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Stage 1: OnRequest hooks
 	r.runHooks(models.HookOnRequest, reqCtx)
 	if reqCtx.Handled {
+		r.applyRedirectIfSet(reqCtx)
 		r.finalizeResponse(reqCtx, wrappedWriter)
 		return
 	}
@@ -563,6 +564,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Stage 2: Before hooks
 	r.runHooks(models.HookBefore, reqCtx)
 	if reqCtx.Handled {
+		r.applyRedirectIfSet(reqCtx)
 		r.finalizeResponse(reqCtx, wrappedWriter)
 		return
 	}
@@ -573,15 +575,35 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Stage 4: After hooks
 	r.runHooks(models.HookAfter, reqCtx)
 	if reqCtx.Handled {
+		r.applyRedirectIfSet(reqCtx)
 		r.finalizeResponse(reqCtx, wrappedWriter)
 		return
 	}
+
+	// Handle declarative redirects: if handler set RedirectURL, prepare redirect response
+	// This happens after HookAfter so that all hooks (including cookie-setting hooks) have run
+	r.applyRedirectIfSet(reqCtx)
 
 	// Stage 5: OnResponse hooks
 	r.runHooks(models.HookOnResponse, reqCtx)
 
 	// Flush deferred writes or captured response
 	r.finalizeResponse(reqCtx, wrappedWriter)
+}
+
+func (r *Router) applyRedirectIfSet(reqCtx *models.RequestContext) {
+	if reqCtx.RedirectURL == "" {
+		return
+	}
+
+	statusCode := reqCtx.ResponseStatus
+	if statusCode == 0 {
+		statusCode = http.StatusFound
+	}
+
+	redirectHeaders := make(http.Header)
+	redirectHeaders.Set("Location", reqCtx.RedirectURL)
+	reqCtx.SetResponse(statusCode, redirectHeaders, nil)
 }
 
 func (r *Router) finalizeResponse(

--- a/router_hooks_test.go
+++ b/router_hooks_test.go
@@ -574,6 +574,42 @@ func TestHookErrorModeSilent(t *testing.T) {
 	}
 }
 
+// TestRouterRedirectHandledRequest ensures RedirectURL responses are honored even when ctx.Handled is true
+func TestRouterRedirectHandledRequest(t *testing.T) {
+	config := &models.Config{
+		BasePath: "/api/auth",
+	}
+	logger := &mockLogger{}
+	router := NewRouter(config, logger, nil)
+	redirectURL := "https://example.com/callback"
+
+	router.RegisterRoute(models.Route{
+		Method: "GET",
+		Path:   "/test",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqCtx, ok := models.GetRequestContext(r.Context())
+			if !ok {
+				t.Fatal("expected request context")
+			}
+			reqCtx.RedirectURL = redirectURL
+			reqCtx.ResponseStatus = http.StatusFound
+			reqCtx.Handled = true
+		}),
+	})
+
+	req := httptest.NewRequest("GET", "/api/auth/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected status %d, got %d", http.StatusFound, w.Code)
+	}
+
+	if location := w.Header().Get("Location"); location != redirectURL {
+		t.Fatalf("expected Location header %q, got %q", redirectURL, location)
+	}
+}
+
 // testHandler is a simple HTTP handler for testing
 type testHandler struct {
 	statusCode int
@@ -589,7 +625,6 @@ func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(h.statusCode)
 	if _, err := w.Write([]byte(h.body)); err != nil {
-		// Log the error instead of panicking to avoid stopping other tests
 		fmt.Printf("failed to write response body: %v\n", err)
 	}
 }


### PR DESCRIPTION
Redirects were not respecting cookies so cookies would never be set properly when a redirect occurred. Now the `RequestContext` object contains a `RedirectURL`. If a RedirectURL is set then during that point in time, hooks will still be able to execute and set cookies before a redirect occurs and this is handy for features such as OAuth2 Callback whereby the backend may want to set the session cookie to authenticate the user before redirecting back to the frontend.