### PR TITLE
refactor: Hooks and public interface of Access Control plugin

### DIFF
--- a/plugins/access-control/hooks.go
+++ b/plugins/access-control/hooks.go
@@ -1,7 +1,6 @@
 package accesscontrol
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/Authula/authula/internal/util"
@@ -22,20 +21,22 @@ func (id AccessControlHookID) String() string {
 func (p *AccessControlPlugin) Hooks() []models.Hook {
 	return []models.Hook{
 		{
-			Stage:   models.HookAfter,
-			Handler: p.assignRoleFromContextHook,
-			Order:   20,
-		},
-		{
 			Stage:    models.HookBefore,
 			PluginID: HookIDAccessControlEnforce.String(),
 			Handler:  p.requireAccessControl,
 			Order:    20,
 		},
+		{
+			Stage:   models.HookAfter,
+			Handler: p.assignRoleFromContextHook,
+			Order:   20,
+		},
 	}
 }
 
 func (p *AccessControlPlugin) assignRoleFromContextHook(reqCtx *models.RequestContext) error {
+	ctx := reqCtx.Request.Context()
+
 	rawValue, ok := reqCtx.Values[models.ContextAccessControlAssignRole.String()]
 	if !ok || rawValue == nil {
 		return nil
@@ -46,7 +47,12 @@ func (p *AccessControlPlugin) assignRoleFromContextHook(reqCtx *models.RequestCo
 		return nil
 	}
 
-	ctx := reqCtx.Request.Context()
+	targetRole, err := p.Api.GetRoleByName(ctx, assignCtx.RoleName)
+	if err != nil {
+		p.logAssignRoleHookError("failed to resolve role", assignCtx, err)
+		return nil
+	}
+
 	userRoles, err := p.Api.GetUserRoles(ctx, assignCtx.UserID)
 	if err != nil {
 		p.logAssignRoleHookError("failed to load user roles", assignCtx, err)
@@ -59,17 +65,7 @@ func (p *AccessControlPlugin) assignRoleFromContextHook(reqCtx *models.RequestCo
 		}
 	}
 
-	role, err := p.Api.GetRoleByName(ctx, assignCtx.RoleName)
-	if err != nil {
-		p.logAssignRoleHookError("failed to resolve role", assignCtx, err)
-		return nil
-	}
-	if role == nil || role.ID == "" {
-		p.logAssignRoleHookError("resolved role is empty", assignCtx, fmt.Errorf("role not found"))
-		return nil
-	}
-
-	if err := p.Api.AssignRoleToUser(ctx, assignCtx.UserID, types.AssignUserRoleRequest{RoleID: role.ID}, assignCtx.AssignerUserID); err != nil {
+	if err := p.Api.AssignRoleToUser(ctx, assignCtx.UserID, types.AssignUserRoleRequest{RoleID: targetRole.ID}, assignCtx.AssignerUserID); err != nil {
 		p.logAssignRoleHookError("failed to assign role", assignCtx, err)
 	}
 
@@ -77,10 +73,15 @@ func (p *AccessControlPlugin) assignRoleFromContextHook(reqCtx *models.RequestCo
 }
 
 func (p *AccessControlPlugin) logAssignRoleHookError(message string, assignCtx models.AccessControlAssignRoleContext, err error) {
+	assignerUserID := "not provided"
+	if assignCtx.AssignerUserID != nil && *assignCtx.AssignerUserID != "" {
+		assignerUserID = *assignCtx.AssignerUserID
+	}
 	p.logger.Error(
 		message,
 		"user_id", assignCtx.UserID,
 		"role_name", assignCtx.RoleName,
+		"assigned_by_user_id", assignerUserID,
 		"error", err,
 	)
 }

--- a/plugins/access-control/hooks_test.go
+++ b/plugins/access-control/hooks_test.go
@@ -18,18 +18,22 @@ import (
 )
 
 func newAccessControlHookTestPlugin(logger authmodels.Logger, rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) *AccessControlPlugin {
+	rolesService := services.NewRolesService(rolesRepo, nil, userRolesRepo)
+	userRolesService := services.NewUserRolesService(userRolesRepo, rolesRepo)
+	accessControlService := services.NewAccessControlService(rolesService, userRolesService)
 	rolePermissionsService := services.NewRolePermissionsService(nil, nil, nil)
 	useCases := usecases.NewAccessControlUseCases(
-		usecases.NewRolesUseCase(services.NewRolesService(rolesRepo, nil, userRolesRepo)),
+		usecases.NewRolesUseCase(rolesService),
 		usecases.NewPermissionsUseCase(nil),
 		usecases.NewRolePermissionsUseCase(rolePermissionsService),
-		usecases.NewUserRolesUseCase(services.NewUserRolesService(userRolesRepo, rolesRepo)),
+		usecases.NewUserRolesUseCase(userRolesService),
 		usecases.NewUserPermissionsUseCase(nil),
 	)
 
 	return &AccessControlPlugin{
-		Api:    NewAPI(useCases),
-		logger: logger,
+		Api:                  NewAPI(useCases),
+		logger:               logger,
+		accessControlService: accessControlService,
 	}
 }
 
@@ -69,6 +73,7 @@ func TestAccessControlPluginAssignRoleFromContextHook(t *testing.T) {
 			name:         "already assigned role is skipped",
 			contextValue: authmodels.AccessControlAssignRoleContext{UserID: "user-1", RoleName: "Editor"},
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "Editor").Return(&types.Role{ID: "role-1", Name: "Editor", Weight: 10}, nil).Once()
 				userRolesRepo.On("GetUserRoles", mock.Anything, "user-1").Return([]types.UserRoleInfo{{RoleID: "role-1", RoleName: "Editor", RoleWeight: 10}}, nil).Once()
 			},
 		},
@@ -76,9 +81,9 @@ func TestAccessControlPluginAssignRoleFromContextHook(t *testing.T) {
 			name:         "assigns role when missing",
 			contextValue: authmodels.AccessControlAssignRoleContext{UserID: "user-1", RoleName: "Editor", AssignerUserID: func() *string { v := "assigner-1"; return &v }()},
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "Editor").Return(&types.Role{ID: "role-1", Name: "Editor", Weight: 10}, nil).Once()
 				userRolesRepo.On("GetUserRoles", mock.Anything, "user-1").Return([]types.UserRoleInfo{}, nil).Once()
 				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-1").Return([]types.UserRoleInfo{{RoleID: "role-owner", RoleName: "Owner", RoleWeight: 50}}, nil).Once()
-				rolesRepo.On("GetRoleByName", mock.Anything, "Editor").Return(&types.Role{ID: "role-1", Name: "Editor", Weight: 10}, nil).Once()
 				rolesRepo.On("GetRoleByID", mock.Anything, "role-1").Return(&types.Role{ID: "role-1", Name: "Editor", Weight: 10}, nil).Once()
 				userRolesRepo.On("AssignUserRole", mock.Anything, "user-1", "role-1", mock.MatchedBy(func(userID *string) bool {
 					return userID != nil && *userID == "assigner-1"
@@ -87,9 +92,8 @@ func TestAccessControlPluginAssignRoleFromContextHook(t *testing.T) {
 		},
 		{
 			name:         "role lookup failure is logged and ignored",
-			contextValue: authmodels.AccessControlAssignRoleContext{UserID: "user-1", RoleName: "Editor"},
+			contextValue: authmodels.AccessControlAssignRoleContext{UserID: "user-1", RoleName: "Editor", AssignerUserID: func() *string { v := "assigner-1"; return &v }()},
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
-				userRolesRepo.On("GetUserRoles", mock.Anything, "user-1").Return([]types.UserRoleInfo{}, nil).Once()
 				rolesRepo.On("GetRoleByName", mock.Anything, "Editor").Return((*types.Role)(nil), errors.New("lookup failed")).Once()
 			},
 		},
@@ -97,8 +101,8 @@ func TestAccessControlPluginAssignRoleFromContextHook(t *testing.T) {
 			name:         "assignment failure is logged and ignored",
 			contextValue: authmodels.AccessControlAssignRoleContext{UserID: "user-1", RoleName: "Editor"},
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
-				userRolesRepo.On("GetUserRoles", mock.Anything, "user-1").Return([]types.UserRoleInfo{}, nil).Once()
 				rolesRepo.On("GetRoleByName", mock.Anything, "Editor").Return(&types.Role{ID: "role-1", Name: "Editor", Weight: 10}, nil).Once()
+				userRolesRepo.On("GetUserRoles", mock.Anything, "user-1").Return([]types.UserRoleInfo{}, nil).Once()
 				rolesRepo.On("GetRoleByID", mock.Anything, "role-1").Return(&types.Role{ID: "role-1", Name: "Editor", Weight: 10}, nil).Once()
 				userRolesRepo.On("AssignUserRole", mock.Anything, "user-1", "role-1", (*string)(nil), (*time.Time)(nil)).Return(errors.New("assign failed")).Once()
 			},

--- a/plugins/access-control/plugin.go
+++ b/plugins/access-control/plugin.go
@@ -11,10 +11,11 @@ import (
 )
 
 type AccessControlPlugin struct {
-	config types.AccessControlPluginConfig
-	ctx    *models.PluginContext
-	logger models.Logger
-	Api    *API
+	config               types.AccessControlPluginConfig
+	ctx                  *models.PluginContext
+	logger               models.Logger
+	accessControlService *services.AccessControlService
+	Api                  *API
 }
 
 func New(config types.AccessControlPluginConfig) *AccessControlPlugin {
@@ -54,7 +55,8 @@ func (p *AccessControlPlugin) Init(ctx *models.PluginContext) error {
 	userRolesService := services.NewUserRolesService(userRolesRepo, rolesRepo)
 	userPermissionsService := services.NewUserPermissionsService(userPermissionsRepo)
 
-	accessControlService := services.NewAccessControlService(rolesService)
+	accessControlService := services.NewAccessControlService(rolesService, userRolesService)
+	p.accessControlService = accessControlService
 
 	useCases := usecases.NewAccessControlUseCases(
 		usecases.NewRolesUseCase(rolesService),

--- a/plugins/access-control/services/access_control_service.go
+++ b/plugins/access-control/services/access_control_service.go
@@ -1,13 +1,19 @@
 package services
 
-import "context"
+import (
+	"context"
+	"time"
+
+	"github.com/Authula/authula/plugins/access-control/constants"
+)
 
 type AccessControlService struct {
-	rolesService *RolesService
+	rolesService     *RolesService
+	userRolesService *UserRolesService
 }
 
-func NewAccessControlService(rolesService *RolesService) *AccessControlService {
-	return &AccessControlService{rolesService: rolesService}
+func NewAccessControlService(rolesService *RolesService, userRolesService *UserRolesService) *AccessControlService {
+	return &AccessControlService{rolesService: rolesService, userRolesService: userRolesService}
 }
 
 func (s *AccessControlService) RoleExists(ctx context.Context, roleName string) (bool, error) {
@@ -17,4 +23,34 @@ func (s *AccessControlService) RoleExists(ctx context.Context, roleName string) 
 	}
 
 	return role != nil && role.ID != "", nil
+}
+
+func (s *AccessControlService) ValidateRoleAssignment(ctx context.Context, roleName string, assignerUserID *string) (bool, error) {
+	role, err := s.rolesService.GetRoleByName(ctx, roleName)
+	if err != nil {
+		return false, err
+	}
+	if role == nil || role.ID == "" {
+		return false, constants.ErrNotFound
+	}
+
+	if assignerUserID == nil || *assignerUserID == "" {
+		return false, nil
+	}
+
+	assignerRoles, err := s.userRolesService.GetUserRoles(ctx, *assignerUserID)
+	if err != nil {
+		return false, err
+	}
+
+	highestWeight, activeCount := determineHighestActiveRoleWeight(assignerRoles, time.Now().UTC())
+	if activeCount == 0 {
+		return false, constants.ErrForbidden
+	}
+
+	if role.Weight > highestWeight {
+		return false, constants.ErrForbidden
+	}
+
+	return true, nil
 }

--- a/plugins/access-control/services/access_control_service_test.go
+++ b/plugins/access-control/services/access_control_service_test.go
@@ -12,10 +12,74 @@ import (
 	"github.com/Authula/authula/plugins/access-control/types"
 )
 
+func TestAccessControlServiceRoleExists(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		roleName string
+		setup    func(*accesscontroltests.MockRolesRepository)
+		wantErr  error
+		wantOK   bool
+	}{
+		{
+			name:     "role not found",
+			roleName: "missing",
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "missing").Return((*types.Role)(nil), nil).Once()
+			},
+			wantErr: accesscontrolconstants.ErrNotFound,
+			wantOK:  false,
+		},
+		{
+			name:     "role exists",
+			roleName: "editor",
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return(&types.Role{ID: "role-1", Name: "editor", Weight: 10}, nil).Once()
+			},
+			wantOK: true,
+		},
+		{
+			name:     "repository error",
+			roleName: "editor",
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return((*types.Role)(nil), accesscontrolconstants.ErrForbidden).Once()
+			},
+			wantErr: accesscontrolconstants.ErrForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rolesRepo := &accesscontroltests.MockRolesRepository{}
+			if tc.setup != nil {
+				tc.setup(rolesRepo)
+			}
+
+			service := NewAccessControlService(NewRolesService(rolesRepo, nil, nil), NewUserRolesService(nil, nil))
+			ok, err := service.RoleExists(context.Background(), tc.roleName)
+			if err != tc.wantErr {
+				t.Fatalf("expected err %v, got %v", tc.wantErr, err)
+			}
+			if tc.wantErr != nil {
+				if ok {
+					t.Fatalf("expected false, got true")
+				}
+			} else if ok != tc.wantOK {
+				t.Fatalf("unexpected result %v", ok)
+			}
+
+			rolesRepo.AssertExpectations(t)
+		})
+	}
+}
+
 func TestAccessControlServiceValidateRoleAssignment(t *testing.T) {
 	t.Parallel()
 
-	assignerID := func() *string { value := "assigner-1"; return &value }()
+	assignerUserID := func() *string { value := "assigner-user-1"; return &value }()
 
 	tests := []struct {
 		name     string
@@ -34,31 +98,31 @@ func TestAccessControlServiceValidateRoleAssignment(t *testing.T) {
 			wantErr: accesscontrolconstants.ErrNotFound,
 		},
 		{
-			name:     "success without assigner",
+			name:     "nil assigner is not allowed",
 			roleName: "editor",
 			assigner: nil,
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
 				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return(&types.Role{ID: "role-1", Name: "editor", Weight: 10}, nil).Once()
 			},
-			wantOK: true,
+			wantOK: false,
 		},
 		{
 			name:     "forbidden when assigner has no active roles",
 			roleName: "editor",
-			assigner: assignerID,
+			assigner: assignerUserID,
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
 				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return(&types.Role{ID: "role-1", Name: "editor", Weight: 10}, nil).Once()
-				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-1").Return([]types.UserRoleInfo{{RoleID: "role-old", RoleName: "old", RoleWeight: 100, ExpiresAt: func() *time.Time { value := time.Now().UTC().Add(-time.Hour); return &value }()}}, nil).Once()
+				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-user-1").Return([]types.UserRoleInfo{{RoleID: "role-old", RoleName: "old", RoleWeight: 100, ExpiresAt: func() *time.Time { value := time.Now().UTC().Add(-time.Hour); return &value }()}}, nil).Once()
 			},
 			wantErr: accesscontrolconstants.ErrForbidden,
 		},
 		{
 			name:     "expired roles are ignored",
 			roleName: "editor",
-			assigner: assignerID,
+			assigner: assignerUserID,
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
 				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return(&types.Role{ID: "role-1", Name: "editor", Weight: 20}, nil).Once()
-				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-1").Return([]types.UserRoleInfo{
+				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-user-1").Return([]types.UserRoleInfo{
 					{RoleID: "role-expired", RoleName: "expired", RoleWeight: 100, ExpiresAt: func() *time.Time { value := time.Now().UTC().Add(-time.Hour); return &value }()},
 					{RoleID: "role-active", RoleName: "active", RoleWeight: 30},
 				}, nil).Once()
@@ -68,10 +132,10 @@ func TestAccessControlServiceValidateRoleAssignment(t *testing.T) {
 		{
 			name:     "forbidden when target exceeds assigner weight",
 			roleName: "admin",
-			assigner: assignerID,
+			assigner: assignerUserID,
 			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
 				rolesRepo.On("GetRoleByName", mock.Anything, "admin").Return(&types.Role{ID: "role-2", Name: "admin", Weight: 80}, nil).Once()
-				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-1").Return([]types.UserRoleInfo{{RoleID: "role-member", RoleName: "member", RoleWeight: 10}}, nil).Once()
+				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-user-1").Return([]types.UserRoleInfo{{RoleID: "role-member", RoleName: "member", RoleWeight: 10}}, nil).Once()
 			},
 			wantErr: accesscontrolconstants.ErrForbidden,
 		},

--- a/plugins/access-control/services/access_control_service_test.go
+++ b/plugins/access-control/services/access_control_service_test.go
@@ -1,0 +1,107 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	accesscontrolconstants "github.com/Authula/authula/plugins/access-control/constants"
+	accesscontroltests "github.com/Authula/authula/plugins/access-control/tests"
+	"github.com/Authula/authula/plugins/access-control/types"
+)
+
+func TestAccessControlServiceValidateRoleAssignment(t *testing.T) {
+	t.Parallel()
+
+	assignerID := func() *string { value := "assigner-1"; return &value }()
+
+	tests := []struct {
+		name     string
+		roleName string
+		assigner *string
+		setup    func(*accesscontroltests.MockRolesRepository, *accesscontroltests.MockUserRolesRepository)
+		wantErr  error
+		wantOK   bool
+	}{
+		{
+			name:     "role not found",
+			roleName: "missing",
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "missing").Return((*types.Role)(nil), nil).Once()
+			},
+			wantErr: accesscontrolconstants.ErrNotFound,
+		},
+		{
+			name:     "success without assigner",
+			roleName: "editor",
+			assigner: nil,
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return(&types.Role{ID: "role-1", Name: "editor", Weight: 10}, nil).Once()
+			},
+			wantOK: true,
+		},
+		{
+			name:     "forbidden when assigner has no active roles",
+			roleName: "editor",
+			assigner: assignerID,
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return(&types.Role{ID: "role-1", Name: "editor", Weight: 10}, nil).Once()
+				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-1").Return([]types.UserRoleInfo{{RoleID: "role-old", RoleName: "old", RoleWeight: 100, ExpiresAt: func() *time.Time { value := time.Now().UTC().Add(-time.Hour); return &value }()}}, nil).Once()
+			},
+			wantErr: accesscontrolconstants.ErrForbidden,
+		},
+		{
+			name:     "expired roles are ignored",
+			roleName: "editor",
+			assigner: assignerID,
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "editor").Return(&types.Role{ID: "role-1", Name: "editor", Weight: 20}, nil).Once()
+				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-1").Return([]types.UserRoleInfo{
+					{RoleID: "role-expired", RoleName: "expired", RoleWeight: 100, ExpiresAt: func() *time.Time { value := time.Now().UTC().Add(-time.Hour); return &value }()},
+					{RoleID: "role-active", RoleName: "active", RoleWeight: 30},
+				}, nil).Once()
+			},
+			wantOK: true,
+		},
+		{
+			name:     "forbidden when target exceeds assigner weight",
+			roleName: "admin",
+			assigner: assignerID,
+			setup: func(rolesRepo *accesscontroltests.MockRolesRepository, userRolesRepo *accesscontroltests.MockUserRolesRepository) {
+				rolesRepo.On("GetRoleByName", mock.Anything, "admin").Return(&types.Role{ID: "role-2", Name: "admin", Weight: 80}, nil).Once()
+				userRolesRepo.On("GetUserRoles", mock.Anything, "assigner-1").Return([]types.UserRoleInfo{{RoleID: "role-member", RoleName: "member", RoleWeight: 10}}, nil).Once()
+			},
+			wantErr: accesscontrolconstants.ErrForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rolesRepo := &accesscontroltests.MockRolesRepository{}
+			userRolesRepo := &accesscontroltests.MockUserRolesRepository{}
+			if tc.setup != nil {
+				tc.setup(rolesRepo, userRolesRepo)
+			}
+
+			service := NewAccessControlService(NewRolesService(rolesRepo, nil, userRolesRepo), NewUserRolesService(userRolesRepo, rolesRepo))
+			ok, err := service.ValidateRoleAssignment(context.Background(), tc.roleName, tc.assigner)
+			if err != tc.wantErr {
+				t.Fatalf("expected err %v, got %v", tc.wantErr, err)
+			}
+			if tc.wantErr != nil {
+				if ok {
+					t.Fatalf("expected false, got true")
+				}
+			} else if ok != tc.wantOK {
+				t.Fatalf("unexpected result %v", ok)
+			}
+
+			rolesRepo.AssertExpectations(t)
+			userRolesRepo.AssertExpectations(t)
+		})
+	}
+}

--- a/plugins/access-control/services/user_roles_service.go
+++ b/plugins/access-control/services/user_roles_service.go
@@ -131,16 +131,24 @@ func (s *UserRolesService) highestActiveRoleWeight(ctx context.Context, userID s
 		return 0, err
 	}
 
+	highestWeight, _ := determineHighestActiveRoleWeight(roles, time.Now().UTC())
+
+	return highestWeight, nil
+}
+
+func determineHighestActiveRoleWeight(userRoles []types.UserRoleInfo, now time.Time) (int, int) {
 	highestWeight := 0
-	now := time.Now().UTC()
-	for _, userRole := range roles {
+	activeCount := 0
+
+	for _, userRole := range userRoles {
 		if userRole.ExpiresAt != nil && userRole.ExpiresAt.Before(now) {
 			continue
 		}
+		activeCount++
 		if userRole.RoleWeight > highestWeight {
 			highestWeight = userRole.RoleWeight
 		}
 	}
 
-	return highestWeight, nil
+	return highestWeight, activeCount
 }

--- a/plugins/access-control/services/user_roles_service_test.go
+++ b/plugins/access-control/services/user_roles_service_test.go
@@ -85,11 +85,11 @@ func TestUserRolesServiceReplaceUserRoles(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		roleIDs        []string
-		assignerUserID *string
-		setup          func(*accesscontroltests.MockUserRolesRepository, *accesscontroltests.MockRolesRepository)
-		wantErr        error
+		name             string
+		roleIDs          []string
+		assignedByUserID *string
+		setup            func(*accesscontroltests.MockUserRolesRepository, *accesscontroltests.MockRolesRepository)
+		wantErr          error
 	}{
 		{
 			name:    "dedupes role ids",
@@ -101,9 +101,9 @@ func TestUserRolesServiceReplaceUserRoles(t *testing.T) {
 			},
 		},
 		{
-			name:           "forbidden when assigner lacks sufficient weight",
-			roleIDs:        []string{"role-1", "role-2"},
-			assignerUserID: func() *string { value := "assigner-1"; return &value }(),
+			name:             "forbidden when assigner lacks sufficient weight",
+			roleIDs:          []string{"role-1", "role-2"},
+			assignedByUserID: func() *string { value := "assigner-1"; return &value }(),
 			setup: func(userRolesRepo *accesscontroltests.MockUserRolesRepository, rolesRepo *accesscontroltests.MockRolesRepository) {
 				rolesRepo.On("GetRoleByID", mock.Anything, "role-1").Return(&types.Role{ID: "role-1", Name: "admin", Weight: 20}, nil).Once()
 				rolesRepo.On("GetRoleByID", mock.Anything, "role-2").Return(&types.Role{ID: "role-2", Name: "editor", Weight: 10}, nil).Once()
@@ -124,7 +124,7 @@ func TestUserRolesServiceReplaceUserRoles(t *testing.T) {
 			}
 
 			service := NewUserRolesService(userRolesRepo, rolesRepo)
-			err := service.ReplaceUserRoles(context.Background(), "user-1", tc.roleIDs, tc.assignerUserID)
+			err := service.ReplaceUserRoles(context.Background(), "user-1", tc.roleIDs, tc.assignedByUserID)
 			if err != tc.wantErr {
 				t.Fatalf("expected err %v, got %v", tc.wantErr, err)
 			}

--- a/services/access_control.go
+++ b/services/access_control.go
@@ -4,4 +4,5 @@ import "context"
 
 type AccessControlService interface {
 	RoleExists(ctx context.Context, roleName string) (bool, error)
+	ValidateRoleAssignment(ctx context.Context, roleName string, assignedByUserID *string) (bool, error)
 }


### PR DESCRIPTION
- Added `ValidateRoleAssignment` method to the public access control interface to allow other plugins to be able to validate a role before assignment.
- Wrote complete tests for this public service
- Refactored the hooks.go slightly 