### PR TITLE
refactor: Route Mappings

### DIFF
--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -123,30 +123,62 @@ func getEnabledFromConfig(config any) (bool, bool) {
 
 // ConvertRouteMetadata converts a list of RouteMapping configs into the internal
 // route metadata map used by the router for plugin routing.
-// Returns a map keyed by "METHOD:path" containing metadata with "plugins" field.
-// Example:
-//
-//	Input: RouteMapping{Path: "/me", Method: "GET", Plugins: ["session.auth"]}
-//	Output: {"GET:/me": {"plugins": ["session.auth"]}}
+// Returns a map keyed by "METHOD:path" containing metadata with "plugins" and "permissions" fields.
+// Route strings can either be METHOD:/path or just /path.
+// Bare paths apply to all supported HTTP methods.
 func ConvertRouteMetadata(routes []models.RouteMapping) (map[string]map[string]any, error) {
 	result := make(map[string]map[string]any)
 
 	for _, route := range routes {
-		if route.Path == "" {
-			return nil, fmt.Errorf("route path cannot be empty")
-		}
-		if route.Method == "" {
-			return nil, fmt.Errorf("route method cannot be empty for path %s", route.Path)
+		if len(route.Paths) == 0 {
+			return nil, fmt.Errorf("route paths cannot be empty")
 		}
 
-		key := route.Method + ":" + route.Path
-		metadata := make(map[string]any)
-		metadata["plugins"] = route.Plugins
-		metadata["permissions"] = route.Permissions
-		result[key] = metadata
+		for _, routePath := range route.Paths {
+			trimmed := strings.TrimSpace(routePath)
+			if trimmed == "" {
+				return nil, fmt.Errorf("route path cannot be empty")
+			}
+
+			methods, pattern, err := parseRouteMappingPath(trimmed)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, method := range methods {
+				key := method + ":" + pattern
+				metadata := result[key]
+				if metadata == nil {
+					metadata = make(map[string]any)
+					result[key] = metadata
+				}
+
+				metadata["plugins"] = MergeStringSlices(ReadStringSliceFromMetadata(metadata, "plugins"), route.Plugins)
+				metadata["permissions"] = MergeStringSlices(ReadStringSliceFromMetadata(metadata, "permissions"), route.Permissions)
+			}
+		}
 	}
 
 	return result, nil
+}
+
+func parseRouteMappingPath(routePath string) ([]string, string, error) {
+	if strings.HasPrefix(routePath, "/") {
+		return SupportedRouteMethods, NormalizeRoutePattern(routePath), nil
+	}
+
+	parts := strings.SplitN(routePath, ":", 2)
+	if len(parts) != 2 {
+		return nil, "", fmt.Errorf("route path must be either METHOD:/path or /path, got %q", routePath)
+	}
+
+	method := strings.ToUpper(strings.TrimSpace(parts[0]))
+	pattern := NormalizeRoutePattern(parts[1])
+	if method == "" {
+		return nil, "", fmt.Errorf("route method cannot be empty for path %q", routePath)
+	}
+
+	return []string{method}, pattern, nil
 }
 
 // ApplyBasePathToMetadataKey applies a basePath prefix to a metadata key (METHOD:path)

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/http"
 	"strings"
 	"time"
 
@@ -165,4 +166,81 @@ func ReadStringSliceMetadata(reqCtx *models.RequestContext, key string) []string
 	}
 
 	return nil
+}
+
+var SupportedRouteMethods = []string{
+	http.MethodGet,
+	http.MethodPost,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
+}
+
+func ReadStringSliceFromMetadata(metadata map[string]any, key string) []string {
+	if metadata == nil {
+		return nil
+	}
+
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return nil
+	}
+
+	if values, ok := raw.([]string); ok {
+		result := make([]string, 0, len(values))
+		for _, value := range values {
+			trimmed := strings.TrimSpace(value)
+			if trimmed != "" {
+				result = append(result, trimmed)
+			}
+		}
+		return result
+	}
+
+	if valuesAny, ok := raw.([]any); ok {
+		result := make([]string, 0, len(valuesAny))
+		for _, value := range valuesAny {
+			str, ok := value.(string)
+			if !ok {
+				continue
+			}
+
+			trimmed := strings.TrimSpace(str)
+			if trimmed != "" {
+				result = append(result, trimmed)
+			}
+		}
+		return result
+	}
+
+	return nil
+}
+
+func MergeStringSlices(values ...[]string) []string {
+	merged := make([]string, 0)
+	seen := make(map[string]struct{})
+
+	for _, items := range values {
+		for _, value := range items {
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			merged = append(merged, trimmed)
+		}
+	}
+
+	return merged
+}
+
+func NormalizeRoutePattern(pattern string) string {
+	trimmed := NormalizePath(pattern)
+	if trimmed == "/" {
+		return trimmed
+	}
+	return strings.ReplaceAll(trimmed, "//", "/")
 }

--- a/models/config.go
+++ b/models/config.go
@@ -21,7 +21,8 @@ type Config struct {
 	EventBus     EventBusConfig     `json:"event_bus" toml:"event_bus"`
 	Plugins      PluginsConfig      `json:"plugins" toml:"plugins"`
 	// RouteMappings defines plugin-to-route mappings.
-	// Each route specifies which plugins should execute hooks for that endpoint.
+	// Each entry can declare multiple routes in Paths using METHOD:/path strings.
+	// A path without a method prefix applies to all HTTP methods.
 	// This enables fully declarative plugin routing in both standalone and library modes.
 	RouteMappings []RouteMapping `json:"route_mappings" toml:"route_mappings"`
 	// PreParsedConfigs stores the original typed plugin config objects.
@@ -132,21 +133,19 @@ type SocialProviderConfig struct {
 // PluginsConfig maps plugin IDs to their configurations
 type PluginsConfig map[string]any
 
-// RouteMapping defines which plugins should execute for a specific route.
-// Used in both standalone and library modes to declaratively map routes to plugins.
+// RouteMapping defines which plugins should execute for one or more routes.
+// Used in both standalone and library modes to declaratively map route patterns to plugins.
 // Standalone: via config.toml [[route_mappings]] table
 // Library: via config.RouteMappings or WithRouteMappings option
+//
 // Example:
 //
 //	[[route_mappings]]
-//	path = "/auth/me"
-//	method = "GET"
+//	paths = ["GET:/auth/me", "/admin/*"]
 //	plugins = ["session.auth", "bearer.auth"]
-//
-// permissions = ["users.read"]
+//	permissions = ["users.read"]
 type RouteMapping struct {
-	Path        string   `json:"path" toml:"path"`
-	Method      string   `json:"method" toml:"method"`
+	Paths       []string `json:"paths" toml:"paths"`
 	Plugins     []string `json:"plugins" toml:"plugins"`
 	Permissions []string `json:"permissions" toml:"permissions"`
 }

--- a/plugins/admin/plugin.go
+++ b/plugins/admin/plugin.go
@@ -99,9 +99,6 @@ func (p *AdminPlugin) DependsOn() []string {
 }
 
 func (p *AdminPlugin) Routes() []models.Route {
-	if p.Api == nil {
-		return []models.Route{}
-	}
 	return Routes(p.Api)
 }
 

--- a/plugins/email-password/types/types.go
+++ b/plugins/email-password/types/types.go
@@ -7,12 +7,11 @@ import (
 )
 
 type EmailPasswordPluginConfig struct {
-	Enabled                  bool `json:"enabled" toml:"enabled"`
-	MinPasswordLength        int  `json:"min_password_length" toml:"min_password_length"`
-	MaxPasswordLength        int  `json:"max_password_length" toml:"max_password_length"`
-	DisableSignUp            bool `json:"disable_sign_up" toml:"disable_sign_up"`
-	RequireEmailVerification bool `json:"require_email_verification" toml:"require_email_verification"`
-	// Whether to automatically sign in the user after sign-up
+	Enabled                     bool          `json:"enabled" toml:"enabled"`
+	MinPasswordLength           int           `json:"min_password_length" toml:"min_password_length"`
+	MaxPasswordLength           int           `json:"max_password_length" toml:"max_password_length"`
+	DisableSignUp               bool          `json:"disable_sign_up" toml:"disable_sign_up"`
+	RequireEmailVerification    bool          `json:"require_email_verification" toml:"require_email_verification"`
 	AutoSignIn                  bool          `json:"auto_sign_in" toml:"auto_sign_in"`
 	SendEmailOnSignUp           bool          `json:"send_email_on_sign_up" toml:"send_email_on_sign_up"`
 	SendEmailOnSignIn           bool          `json:"send_email_on_sign_in" toml:"send_email_on_sign_in"`

--- a/router.go
+++ b/router.go
@@ -142,10 +142,9 @@ func (r *Router) RegisterCustomRouteGroup(group models.RouteGroup) {
 		if route.Metadata != nil {
 			newMetadata := maps.Clone(group.Metadata)
 			maps.Copy(newMetadata, route.Metadata)
-			setMergedPlugins(
-				newMetadata,
-				metadataStringSlice(group.Metadata, "plugins"),
-				metadataStringSlice(route.Metadata, "plugins"),
+			newMetadata["plugins"] = util.MergeStringSlices(
+				util.ReadStringSliceFromMetadata(group.Metadata, "plugins"),
+				util.ReadStringSliceFromMetadata(route.Metadata, "plugins"),
 			)
 			route.Metadata = newMetadata
 		} else {
@@ -207,10 +206,15 @@ func (r *Router) SetRouteMetadataFromConfig(routeMetadata map[string]map[string]
 		fullKey := method + ":" + path
 
 		if existing, ok := r.routeMetadata[fullKey]; ok {
-			existingPlugins := metadataStringSlice(existing, "plugins")
-			incomingPlugins := metadataStringSlice(metadata, "plugins")
 			maps.Copy(existing, metadata)
-			setMergedPlugins(existing, existingPlugins, incomingPlugins)
+			existing["plugins"] = util.MergeStringSlices(
+				util.ReadStringSliceFromMetadata(existing, "plugins"),
+				util.ReadStringSliceFromMetadata(metadata, "plugins"),
+			)
+			existing["permissions"] = util.MergeStringSlices(
+				util.ReadStringSliceFromMetadata(existing, "permissions"),
+				util.ReadStringSliceFromMetadata(metadata, "permissions"),
+			)
 			r.routeMetadata[fullKey] = existing
 		} else {
 			r.routeMetadata[fullKey] = metadata
@@ -240,10 +244,15 @@ func (r *Router) registerRouteWithPrefix(basePath string, route models.Route) {
 	if route.Metadata != nil {
 		metadataKey := route.Method + ":" + path
 		if existing, ok := r.routeMetadata[metadataKey]; ok {
-			existingPlugins := metadataStringSlice(existing, "plugins")
-			incomingPlugins := metadataStringSlice(route.Metadata, "plugins")
 			maps.Copy(existing, route.Metadata)
-			setMergedPlugins(existing, existingPlugins, incomingPlugins)
+			existing["plugins"] = util.MergeStringSlices(
+				util.ReadStringSliceFromMetadata(existing, "plugins"),
+				util.ReadStringSliceFromMetadata(route.Metadata, "plugins"),
+			)
+			existing["permissions"] = util.MergeStringSlices(
+				util.ReadStringSliceFromMetadata(existing, "permissions"),
+				util.ReadStringSliceFromMetadata(route.Metadata, "permissions"),
+			)
 			r.routeMetadata[metadataKey] = existing
 		} else {
 			r.routeMetadata[metadataKey] = route.Metadata
@@ -263,10 +272,6 @@ func (r *Router) registerRouteWithPrefix(basePath string, route models.Route) {
 		r.router.Patch(path, handler.ServeHTTP)
 	case http.MethodDelete:
 		r.router.Delete(path, handler.ServeHTTP)
-	case http.MethodHead:
-		r.router.Head(path, handler.ServeHTTP)
-	case http.MethodOptions:
-		r.router.Options(path, handler.ServeHTTP)
 	default:
 		r.router.MethodFunc(method, path, handler.ServeHTTP)
 	}
@@ -318,8 +323,8 @@ func (r *Router) runHooks(stage models.HookStage, ctx *models.RequestContext) {
 				continue
 			}
 
-			pluginIDs, ok := ctx.Route.Metadata["plugins"].([]string)
-			if !ok || !slices.Contains(pluginIDs, hook.PluginID) {
+			pluginIDs := util.ReadStringSliceFromMetadata(ctx.Route.Metadata, "plugins")
+			if !slices.Contains(pluginIDs, hook.PluginID) {
 				continue
 			}
 		}
@@ -404,60 +409,6 @@ func (r *Router) handleHookError(pluginID string, stage models.HookStage, err er
 	}
 }
 
-func setMergedPlugins(target map[string]any, values ...[]string) {
-	if target == nil {
-		return
-	}
-
-	merged := make([]string, 0)
-	seen := make(map[string]struct{})
-
-	appendUnique := func(items []string) {
-		for _, plugin := range items {
-			trimmed := strings.TrimSpace(plugin)
-			if trimmed == "" {
-				continue
-			}
-			if _, exists := seen[trimmed]; exists {
-				continue
-			}
-			seen[trimmed] = struct{}{}
-			merged = append(merged, trimmed)
-		}
-	}
-
-	for _, items := range values {
-		appendUnique(items)
-	}
-
-	if len(merged) == 0 {
-		delete(target, "plugins")
-		return
-	}
-
-	target["plugins"] = merged
-}
-
-func metadataStringSlice(metadata map[string]any, key string) []string {
-	if metadata == nil {
-		return nil
-	}
-
-	raw, ok := metadata[key]
-	if !ok || raw == nil {
-		return nil
-	}
-
-	values, ok := raw.([]string)
-	if !ok {
-		return nil
-	}
-
-	cloned := make([]string, len(values))
-	copy(cloned, values)
-	return cloned
-}
-
 func matchRoutePath(requestPath, pattern string) bool {
 	normalize := func(p string) []string {
 		p = strings.Trim(p, "/")
@@ -470,11 +421,18 @@ func matchRoutePath(requestPath, pattern string) bool {
 	reqSegs := normalize(requestPath)
 	patSegs := normalize(pattern)
 
-	if len(reqSegs) != len(patSegs) {
-		return false
-	}
+	for i := range patSegs {
+		if i >= len(reqSegs) {
+			if patSegs[i] == "*" && i == len(patSegs)-1 {
+				return true
+			}
+			return false
+		}
 
-	for i := range reqSegs {
+		if patSegs[i] == "*" && i == len(patSegs)-1 {
+			return true
+		}
+
 		if strings.HasPrefix(patSegs[i], "{") && strings.HasSuffix(patSegs[i], "}") {
 			continue
 		}
@@ -482,7 +440,8 @@ func matchRoutePath(requestPath, pattern string) bool {
 			return false
 		}
 	}
-	return true
+
+	return len(reqSegs) == len(patSegs)
 }
 
 // getRouteMetadata looks up route metadata for a given request method and path.

--- a/router_metadata_test.go
+++ b/router_metadata_test.go
@@ -197,18 +197,15 @@ func TestPluginIDBasedHookExecution(t *testing.T) {
 func TestRouteMetadataConversion(t *testing.T) {
 	routes := []models.RouteMapping{
 		{
-			Path:    "/resource/list",
-			Method:  "GET",
+			Paths:   []string{"GET:/resource/list"},
 			Plugins: []string{"plugin.auth", "plugin.verification"},
 		},
 		{
-			Path:    "/resource/create",
-			Method:  "POST",
+			Paths:   []string{"POST:/resource/create"},
 			Plugins: []string{"plugin.process"},
 		},
 		{
-			Path:    "/resource/update",
-			Method:  "POST",
+			Paths:   []string{"POST:/resource/update"},
 			Plugins: []string{"plugin.auth", "plugin.validation"},
 		},
 	}
@@ -261,6 +258,39 @@ func TestRouteMetadataConversion(t *testing.T) {
 
 	if len(pluginIDs) != 2 || pluginIDs[0] != "plugin.auth" || pluginIDs[1] != "plugin.validation" {
 		t.Errorf("unexpected plugins for %s: %v", key, pluginIDs)
+	}
+}
+
+func TestRouteMetadataConversionSupportsBareWildcardPaths(t *testing.T) {
+	routes := []models.RouteMapping{
+		{
+			Paths:       []string{"/admin/*"},
+			Plugins:     []string{"plugin.admin"},
+			Permissions: []string{"admin.read"},
+		},
+	}
+
+	metadata, err := util.ConvertRouteMetadata(routes)
+	if err != nil {
+		t.Fatalf("ConvertRouteMetadata failed: %v", err)
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		key := method + ":/admin/*"
+		entry, exists := metadata[key]
+		if !exists {
+			t.Fatalf("expected wildcard key %s in metadata", key)
+		}
+
+		plugins, ok := entry["plugins"].([]string)
+		if !ok || len(plugins) != 1 || plugins[0] != "plugin.admin" {
+			t.Fatalf("unexpected plugins for %s: %v", key, entry["plugins"])
+		}
+
+		permissions, ok := entry["permissions"].([]string)
+		if !ok || len(permissions) != 1 || permissions[0] != "admin.read" {
+			t.Fatalf("unexpected permissions for %s: %v", key, entry["permissions"])
+		}
 	}
 }
 


### PR DESCRIPTION
`route_mappings` have now been refactored and simplified to:

```toml
# Core routes

[[route_mappings]]
paths = ["GET:/me", "POST:/sign-out"]
plugins = ["session.auth"]

# Email Password Routes

[[route_mappings]]
paths = [
  "POST:/email-password/sign-up", 
  "POST:/email-password/sign-in", 
  "POST:/email-password/verify-email"
]
plugins = ["session.auth.optional"]

[[route_mappings]]
paths = [
  "POST:/email-password/send-email-verification", 
  "POST:/email-password/request-password-reset", 
  "POST:/email-password/change-password",
  "POST:/email-password/request-email-change"
]
plugins = ["session.auth", "csrf.protect"]

# Organization Routes

[[route_mappings]]
paths = ["/organizations/*"]
plugins = ["session.auth"]
```

Benefits of this approach:
- You can now apply plugin capabilities directly to a plugin's routes using a wildcard so the router will automatically apply it to all routes within that plugin.
- It's now a simple one-liner compared to declaring each and every route as individual items within the route_mappings array and providing path and method properties etc.
- It's now been consolidated into a single field called `paths` which is an array of `method+path` combinations or a path without a method that can be a wildcard like shown above.  