### PR TITLE
refactor: User ID handling to principal auth context

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -240,12 +240,12 @@ func (auth *Auth) RegisterHooks(hooks []models.Hook) {
 	auth.router.RegisterHooks(hooks)
 }
 
-// GetUserIDFromContext retrieves the user ID from a context.
-// Returns the user ID and a boolean indicating whether it was found.
-// This is a convenience wrapper around models.GetUserIDFromContext to avoid
+// GetPrincipalFromContext retrieves the principal from a context.
+// Returns the principal and a boolean indicating whether it was found.
+// This is a convenience wrapper around models.GetPrincipalFromContext to avoid
 // requiring application code to import the models package.
-func (auth *Auth) GetUserIDFromContext(ctx context.Context) (string, bool) {
-	return models.GetUserIDFromContext(ctx)
+func (auth *Auth) GetPrincipalFromContext(ctx context.Context) (*models.Actor, bool) {
+	return models.GetActorFromContext(ctx)
 }
 
 // GetActorFromContext retrieves the Actor from a context.
@@ -260,8 +260,8 @@ func (auth *Auth) GetActorFromContext(ctx context.Context) (*models.Actor, bool)
 // Returns the user ID and a boolean indicating whether it was found.
 // This is a convenience wrapper around models.GetUserIDFromRequest to avoid
 // requiring application code to import the models package.
-func (auth *Auth) GetUserIDFromRequest(req *http.Request) (string, bool) {
-	return models.GetUserIDFromRequest(req)
+func (auth *Auth) GetPrincipalFromRequest(req *http.Request) (*models.Actor, bool) {
+	return models.GetActorFromRequest(req)
 }
 
 // GetActorFromRequest retrieves the Actor from an HTTP request's context.

--- a/auth.go
+++ b/auth.go
@@ -240,28 +240,12 @@ func (auth *Auth) RegisterHooks(hooks []models.Hook) {
 	auth.router.RegisterHooks(hooks)
 }
 
-// GetPrincipalFromContext retrieves the principal from a context.
-// Returns the principal and a boolean indicating whether it was found.
-// This is a convenience wrapper around models.GetPrincipalFromContext to avoid
-// requiring application code to import the models package.
-func (auth *Auth) GetPrincipalFromContext(ctx context.Context) (*models.Actor, bool) {
-	return models.GetActorFromContext(ctx)
-}
-
 // GetActorFromContext retrieves the Actor from a context.
 // Returns the Actor and a boolean indicating whether it was found.
 // This is a convenience wrapper around models.GetActorFromContext to avoid
 // requiring application code to import the models package.
 func (auth *Auth) GetActorFromContext(ctx context.Context) (*models.Actor, bool) {
 	return models.GetActorFromContext(ctx)
-}
-
-// GetUserIDFromRequest retrieves the user ID from an HTTP request's context.
-// Returns the user ID and a boolean indicating whether it was found.
-// This is a convenience wrapper around models.GetUserIDFromRequest to avoid
-// requiring application code to import the models package.
-func (auth *Auth) GetPrincipalFromRequest(req *http.Request) (*models.Actor, bool) {
-	return models.GetActorFromRequest(req)
 }
 
 // GetActorFromRequest retrieves the Actor from an HTTP request's context.

--- a/internal/handlers/get_me_handler.go
+++ b/internal/handlers/get_me_handler.go
@@ -17,8 +17,8 @@ func (h *GetMeHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		principal, ok := models.GetActorFromContext(ctx)
+		if !ok || principal == nil || principal.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{
 				"message": "unauthorized",
 			})
@@ -26,7 +26,7 @@ func (h *GetMeHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		result, err := h.UseCase.GetMe(ctx, userID)
+		result, err := h.UseCase.GetMe(ctx, principal.ID)
 		if err != nil {
 			reqCtx.SetJSONResponse(http.StatusInternalServerError, map[string]any{
 				"message": err.Error(),

--- a/internal/handlers/sign_out_handler.go
+++ b/internal/handlers/sign_out_handler.go
@@ -18,8 +18,8 @@ func (h *SignOutHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		principal, ok := models.GetActorFromContext(ctx)
+		if !ok || principal == nil || principal.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{
 				"message": "unauthorized",
 			})
@@ -38,7 +38,7 @@ func (h *SignOutHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		result, err := h.UseCase.SignOut(ctx, userID, request.SessionID, request.SignOutAll)
+		result, err := h.UseCase.SignOut(ctx, principal.ID, request.SessionID, request.SignOutAll)
 		if err != nil {
 			reqCtx.SetJSONResponse(http.StatusInternalServerError, map[string]any{
 				"message": "failed to sign out",

--- a/internal/tests/data_helpers.go
+++ b/internal/tests/data_helpers.go
@@ -25,7 +25,7 @@ func MarshalToJSON(t *testing.T, payload any) []byte {
 	return body
 }
 
-func NewHandlerRequest(t *testing.T, method string, path string, body []byte, userID *string) (*http.Request, *httptest.ResponseRecorder, *models.RequestContext) {
+func NewHandlerRequest(t *testing.T, method string, path string, body []byte, actor *models.Actor) (*http.Request, *httptest.ResponseRecorder, *models.RequestContext) {
 	t.Helper()
 
 	reader := bytes.NewReader(body)
@@ -40,7 +40,9 @@ func NewHandlerRequest(t *testing.T, method string, path string, body []byte, us
 		Headers:        req.Header,
 		ClientIP:       "127.0.0.1",
 		Values:         make(map[string]any),
-		UserID:         userID,
+	}
+	if actor != nil {
+		reqCtx.SetActorInContext(actor)
 	}
 
 	ctx := models.SetRequestContext(context.Background(), reqCtx)

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -47,7 +47,7 @@ func CloneRequestContext(ctx *models.RequestContext) *models.RequestContext {
 		Method:  ctx.Method,
 		Headers: ctx.Headers,
 		Route:   ctx.Route,
-		UserID:  ctx.UserID,
+		Actor:   ctx.Actor,
 		Handled: ctx.Handled,
 	}
 

--- a/models/context.go
+++ b/models/context.go
@@ -11,6 +11,7 @@ type ContextKey string
 const (
 	ContextUserID                       ContextKey = "user_id"
 	ContextAuthActor                    ContextKey = "auth.actor"
+	ContextPrincipal                    ContextKey = "auth.principal"
 	ContextSessionID                    ContextKey = "session_id"
 	ContextSessionToken                 ContextKey = "session_token"
 	ContextRequestContext               ContextKey = "request_context"
@@ -122,33 +123,4 @@ func (reqCtx *RequestContext) SetJSONResponse(status int, payload any) {
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/json")
 	reqCtx.SetResponse(status, headers, data)
-}
-
-func GetUserIDFromContext(ctx context.Context) (string, bool) {
-	// First, check direct Go context (fast path for third-party plugins)
-	value := ctx.Value(ContextUserID)
-	if value != nil {
-		if id, ok := value.(string); ok {
-			return id, true
-		}
-	}
-
-	// Fallback: check RequestContext (for custom runtime)
-	if reqCtx, ok := GetRequestContext(ctx); ok && reqCtx.UserID != nil {
-		return *reqCtx.UserID, true
-	}
-
-	return "", false
-}
-
-// SetUserIDInContext sets the user ID in both the RequestContext and the underlying Go context.
-func (reqCtx *RequestContext) SetUserIDInContext(userID string) {
-	reqCtx.UserID = &userID
-	reqCtx.Request = reqCtx.Request.WithContext(context.WithValue(reqCtx.Request.Context(), ContextUserID, userID))
-}
-
-// GetUserIDFromRequest extracts the user ID from an HTTP request's context.
-// It returns the user ID and a boolean indicating whether it was found.
-func GetUserIDFromRequest(req *http.Request) (string, bool) {
-	return GetUserIDFromContext(req.Context())
 }

--- a/models/context.go
+++ b/models/context.go
@@ -11,7 +11,6 @@ type ContextKey string
 const (
 	ContextUserID                       ContextKey = "user_id"
 	ContextAuthActor                    ContextKey = "auth.actor"
-	ContextPrincipal                    ContextKey = "auth.principal"
 	ContextSessionID                    ContextKey = "session_id"
 	ContextSessionToken                 ContextKey = "session_token"
 	ContextRequestContext               ContextKey = "request_context"

--- a/plugins/access-control/handlers/shared_helpers.go
+++ b/plugins/access-control/handlers/shared_helpers.go
@@ -3,10 +3,11 @@ package handlers
 import "github.com/Authula/authula/models"
 
 func rolePermissionActorUserID(reqCtx *models.RequestContext) *string {
-	if reqCtx.UserID == nil || *reqCtx.UserID == "" {
+	principal, ok := models.GetActorFromContext(reqCtx.Request.Context())
+	if !ok || principal == nil || principal.ID == "" {
 		return nil
 	}
-	return reqCtx.UserID
+	return &principal.ID
 }
 
 func respondRolePermissionError(reqCtx *models.RequestContext, err error) {
@@ -19,10 +20,11 @@ func mapRolePermissionErrorStatus(err error) int {
 }
 
 func userActorUserID(reqCtx *models.RequestContext) *string {
-	if reqCtx.UserID == nil || *reqCtx.UserID == "" {
+	principal, ok := models.GetActorFromContext(reqCtx.Request.Context())
+	if !ok || principal == nil || principal.ID == "" {
 		return nil
 	}
-	return reqCtx.UserID
+	return &principal.ID
 }
 
 func respondUserHandlerError(reqCtx *models.RequestContext, err error) {

--- a/plugins/access-control/hooks.go
+++ b/plugins/access-control/hooks.go
@@ -103,7 +103,8 @@ func accessControlAssignRoleContext(value any) (models.AccessControlAssignRoleCo
 func (p *AccessControlPlugin) requireAccessControl(reqCtx *models.RequestContext) error {
 	ctx := reqCtx.Request.Context()
 
-	if reqCtx.UserID == nil || *reqCtx.UserID == "" {
+	principal := reqCtx.Actor
+	if principal == nil || principal.ID == "" {
 		reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 		reqCtx.Handled = true
 		return nil
@@ -115,7 +116,18 @@ func (p *AccessControlPlugin) requireAccessControl(reqCtx *models.RequestContext
 		return nil
 	}
 
-	allowed, err := p.Api.HasPermissions(ctx, *reqCtx.UserID, requiredPermissions)
+	if len(principal.Permissions) > 0 {
+		for _, permission := range requiredPermissions {
+			if !principal.HasPermission(permission) {
+				reqCtx.SetJSONResponse(http.StatusForbidden, map[string]any{"message": "Forbidden"})
+				reqCtx.Handled = true
+				return nil
+			}
+		}
+		return nil
+	}
+
+	allowed, err := p.Api.HasPermissions(ctx, principal.ID, requiredPermissions)
 	if err != nil {
 		reqCtx.SetJSONResponse(http.StatusInternalServerError, map[string]any{"message": err.Error()})
 		reqCtx.Handled = true

--- a/plugins/admin/handlers/impersonation_handlers.go
+++ b/plugins/admin/handlers/impersonation_handlers.go
@@ -94,7 +94,10 @@ func (h *StartImpersonationHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		reqCtx.SetUserIDInContext(result.Impersonation.TargetUserID)
+		reqCtx.SetActorInContext(&models.Actor{
+			ID:   result.Impersonation.TargetUserID,
+			Type: models.ActorUser,
+		})
 		if result.SessionID != nil && *result.SessionID != "" {
 			reqCtx.Values[models.ContextSessionID.String()] = *result.SessionID
 		}
@@ -143,10 +146,10 @@ func (h *StopImpersonationHandler) Handler() http.HandlerFunc {
 }
 
 func getUserID(reqCtx *models.RequestContext) *string {
-	if reqCtx.UserID == nil || *reqCtx.UserID == "" {
+	if reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 		return nil
 	}
-	return reqCtx.UserID
+	return &reqCtx.Actor.ID
 }
 
 func getSessionID(reqCtx *models.RequestContext) *string {

--- a/plugins/admin/handlers/impersonation_handlers_test.go
+++ b/plugins/admin/handlers/impersonation_handlers_test.go
@@ -117,7 +117,7 @@ func TestStartImpersonationHandler_InvalidJSON(t *testing.T) {
 
 	req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/impersonations", []byte("{invalid"), nil)
 	userID := "actor-1"
-	reqCtx.UserID = &userID
+	reqCtx.SetActorInContext(&models.Actor{ID: userID, Type: models.ActorUser})
 
 	handler.Handler()(w, req)
 
@@ -135,7 +135,7 @@ func TestStartImpersonationHandler_UseCaseError(t *testing.T) {
 
 	req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/impersonations", internaltests.MarshalToJSON(t, types.StartImpersonationRequest{TargetUserID: "target-1", Reason: "support"}), nil)
 	userID := "actor-1"
-	reqCtx.UserID = &userID
+	reqCtx.SetActorInContext(&models.Actor{ID: userID, Type: models.ActorUser})
 
 	handler.Handler()(w, req)
 
@@ -172,7 +172,7 @@ func TestStartImpersonationHandler_SuccessSetsContextValues(t *testing.T) {
 	req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/impersonations", internaltests.MarshalToJSON(t, types.StartImpersonationRequest{TargetUserID: "target-1", Reason: "support"}), nil)
 	req.Header.Set("User-Agent", userAgent)
 	actorID := "actor-1"
-	reqCtx.UserID = &actorID
+	reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 	reqCtx.Values[models.ContextSessionID.String()] = actorSessionID
 
 	handler.Handler()(w, req)
@@ -180,8 +180,8 @@ func TestStartImpersonationHandler_SuccessSetsContextValues(t *testing.T) {
 	if reqCtx.ResponseStatus != http.StatusCreated {
 		t.Fatalf("expected status %d, got %d", http.StatusCreated, reqCtx.ResponseStatus)
 	}
-	if reqCtx.UserID == nil || *reqCtx.UserID != "target-1" {
-		t.Fatalf("expected user id to be target-1, got %v", reqCtx.UserID)
+	if reqCtx.Actor == nil || reqCtx.Actor.ID != "target-1" {
+		t.Fatalf("expected user id to be target-1, got %v", reqCtx.Actor)
 	}
 	if reqCtx.Values[models.ContextSessionID.String()] != sessionID {
 		t.Fatalf("expected session id to be updated, got %v", reqCtx.Values[models.ContextSessionID.String()])
@@ -227,7 +227,7 @@ func TestStopImpersonationHandler(t *testing.T) {
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/impersonations/imp-1/stop", nil, nil)
 		req.SetPathValue("impersonation_id", "imp-1")
 		actorID := "actor-1"
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 
 		handler.Handler()(w, req)
 
@@ -245,7 +245,7 @@ func TestStopImpersonationHandler(t *testing.T) {
 
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/impersonations/imp-1/stop", nil, nil)
 		req.SetPathValue("impersonation_id", "imp-1")
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		reqCtx.Values[models.ContextSessionID.String()] = "session-1"
 
 		handler.Handler()(w, req)
@@ -268,7 +268,7 @@ func TestStopImpersonationHandler(t *testing.T) {
 
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/impersonations/imp-1/stop", nil, nil)
 		req.SetPathValue("impersonation_id", "imp-1")
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		reqCtx.Values[models.ContextSessionID.String()] = "session-1"
 
 		handler.Handler()(w, req)

--- a/plugins/admin/handlers/state_handlers.go
+++ b/plugins/admin/handlers/state_handlers.go
@@ -440,10 +440,10 @@ func (h *RevokeSessionHandler) Handler() http.HandlerFunc {
 }
 
 func stateActorUserID(reqCtx *models.RequestContext) *string {
-	if reqCtx == nil || reqCtx.UserID == nil || *reqCtx.UserID == "" {
+	if reqCtx == nil || reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 		return nil
 	}
-	return reqCtx.UserID
+	return &reqCtx.Actor.ID
 }
 
 func respondStateError(reqCtx *models.RequestContext, err error) {

--- a/plugins/admin/handlers/state_handlers_test.go
+++ b/plugins/admin/handlers/state_handlers_test.go
@@ -99,7 +99,7 @@ func TestUpsertUserStateHandler(t *testing.T) {
 
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPut, "/admin/states/users/user-1", internaltests.MarshalToJSON(t, request), nil)
 		req.SetPathValue("user_id", "user-1")
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		internaltests.AssertErrorMessage(t, reqCtx, http.StatusBadRequest, "bad request")
@@ -121,7 +121,7 @@ func TestUpsertUserStateHandler(t *testing.T) {
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPut, "/admin/states/users/user-1", internaltests.MarshalToJSON(t, request), nil)
 		req.SetPathValue("user_id", "user-1")
 		actorID := "actor-1"
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		if reqCtx.ResponseStatus != http.StatusOK {
@@ -241,7 +241,7 @@ func TestBanUserHandler(t *testing.T) {
 
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/states/users/user-1/ban", internaltests.MarshalToJSON(t, request), nil)
 		req.SetPathValue("user_id", "user-1")
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		internaltests.AssertErrorMessage(t, reqCtx, http.StatusBadRequest, "bad request")
@@ -263,7 +263,7 @@ func TestBanUserHandler(t *testing.T) {
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/states/users/user-1/ban", internaltests.MarshalToJSON(t, request), nil)
 		req.SetPathValue("user_id", "user-1")
 		actorID := "actor-1"
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		if reqCtx.ResponseStatus != http.StatusOK {
@@ -311,7 +311,7 @@ func TestUnbanUserHandler(t *testing.T) {
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/states/users/user-1/unban", nil, nil)
 		req.SetPathValue("user_id", "user-1")
 		actorID := "actor-1"
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		if reqCtx.ResponseStatus != http.StatusOK {
@@ -409,7 +409,7 @@ func TestUpsertSessionStateHandler(t *testing.T) {
 
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPut, "/admin/states/sessions/session-1", internaltests.MarshalToJSON(t, request), nil)
 		req.SetPathValue("session_id", "session-1")
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		internaltests.AssertErrorMessage(t, reqCtx, http.StatusBadRequest, "bad request")
@@ -429,7 +429,7 @@ func TestUpsertSessionStateHandler(t *testing.T) {
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPut, "/admin/states/sessions/session-1", internaltests.MarshalToJSON(t, request), nil)
 		req.SetPathValue("session_id", "session-1")
 		actorID := "actor-1"
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		if reqCtx.ResponseStatus != http.StatusOK {
@@ -612,7 +612,7 @@ func TestRevokeSessionHandler(t *testing.T) {
 		req, w, reqCtx := internaltests.NewHandlerRequest(t, http.MethodPost, "/admin/states/sessions/session-1/revoke", internaltests.MarshalToJSON(t, types.RevokeSessionRequest{Reason: &reason}), nil)
 		req.SetPathValue("session_id", "session-1")
 		actorID := "actor-1"
-		reqCtx.UserID = &actorID
+		reqCtx.SetActorInContext(&models.Actor{ID: actorID, Type: models.ActorUser})
 		handler.Handler()(w, req)
 
 		if reqCtx.ResponseStatus != http.StatusOK {

--- a/plugins/admin/hooks.go
+++ b/plugins/admin/hooks.go
@@ -22,13 +22,13 @@ func (p *AdminPlugin) enforceState(reqCtx *models.RequestContext) error {
 		return nil
 	}
 
-	if reqCtx.UserID == nil || *reqCtx.UserID == "" {
+	if reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 		return nil
 	}
 
 	ctx := reqCtx.Request.Context()
 
-	state, err := p.Api.GetUserState(ctx, *reqCtx.UserID)
+	state, err := p.Api.GetUserState(ctx, reqCtx.Actor.ID)
 	if err != nil {
 		reqCtx.SetJSONResponse(http.StatusInternalServerError, map[string]any{"message": "failed to evaluate user state"})
 		reqCtx.Handled = true

--- a/plugins/bearer/hooks.go
+++ b/plugins/bearer/hooks.go
@@ -35,8 +35,8 @@ func (p *BearerPlugin) buildHooks() []models.Hook {
 }
 
 func (p *BearerPlugin) validateBearerToken(reqCtx *models.RequestContext) error {
-	// Cooperative auth: if UserID already set by another auth plugin, skip
-	if reqCtx.UserID != nil {
+	// Cooperative auth: if a Principal is already set by another auth plugin, skip
+	if reqCtx.Actor != nil {
 		return nil
 	}
 
@@ -58,14 +58,14 @@ func (p *BearerPlugin) validateBearerToken(reqCtx *models.RequestContext) error 
 		return nil
 	}
 
-	reqCtx.SetUserIDInContext(userID)
+	reqCtx.SetActorInContext(&models.Actor{ID: userID, Type: models.ActorUser})
 
 	return nil
 }
 
 func (p *BearerPlugin) validateBearerTokenOptional(reqCtx *models.RequestContext) error {
-	// Cooperative auth: if UserID already set by another auth plugin, skip
-	if reqCtx.UserID != nil {
+	// Cooperative auth: if a Principal is already set by another auth plugin, skip
+	if reqCtx.Actor != nil {
 		return nil
 	}
 
@@ -80,7 +80,7 @@ func (p *BearerPlugin) validateBearerTokenOptional(reqCtx *models.RequestContext
 		return nil
 	}
 
-	reqCtx.SetUserIDInContext(userID)
+	reqCtx.SetActorInContext(&models.Actor{ID: userID, Type: models.ActorUser})
 
 	return nil
 }

--- a/plugins/bearer/plugin.go
+++ b/plugins/bearer/plugin.go
@@ -79,7 +79,7 @@ func (p *BearerPlugin) AuthMiddleware() func(http.Handler) http.Handler {
 				return
 			}
 
-			ctx := context.WithValue(r.Context(), models.ContextUserID, userID)
+			ctx := context.WithValue(r.Context(), models.ContextAuthActor, &models.Actor{ID: userID, Type: models.ActorUser, Permissions: []string{}})
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -91,7 +91,7 @@ func (p *BearerPlugin) OptionalAuthMiddleware() func(http.Handler) http.Handler 
 			token, err := p.extractToken(r)
 			if err == nil && token != "" {
 				if userID, validateErr := p.jwtService.ValidateToken(token); validateErr == nil {
-					ctx := context.WithValue(r.Context(), models.ContextUserID, userID)
+					ctx := context.WithValue(r.Context(), models.ContextAuthActor, &models.Actor{ID: userID, Type: models.ActorUser, Permissions: []string{}})
 					r = r.WithContext(ctx)
 				}
 			}

--- a/plugins/csrf/plugin.go
+++ b/plugins/csrf/plugin.go
@@ -163,7 +163,7 @@ func (p *CSRFPlugin) Middleware() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			reqCtx, ok := models.GetRequestContext(ctx)
-			if !ok || reqCtx.UserID == nil || *reqCtx.UserID == "" {
+			if !ok || reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/plugins/csrf/plugin_test.go
+++ b/plugins/csrf/plugin_test.go
@@ -212,7 +212,7 @@ func TestCSRFPlugin_SafeMethodGenerateTokenOnce(t *testing.T) {
 		ResponseWriter: w1,
 		Path:           "/authenticated",
 		Method:         http.MethodGet,
-		UserID:         userID,
+		Actor:          principalPtr(userID),
 	}
 
 	err := beforeHook.Handler(ctx1)
@@ -236,7 +236,7 @@ func TestCSRFPlugin_SafeMethodGenerateTokenOnce(t *testing.T) {
 		ResponseWriter: w2,
 		Path:           "/authenticated",
 		Method:         http.MethodGet,
-		UserID:         userID,
+		Actor:          principalPtr(userID),
 	}
 
 	err = beforeHook.Handler(ctx2)
@@ -341,7 +341,7 @@ func TestCSRFPlugin_UnsafeMethodValidateToken(t *testing.T) {
 				ResponseWriter: w,
 				Path:           "/authenticated",
 				Method:         tt.method,
-				UserID:         userID,
+				Actor:          principalPtr(userID),
 			}
 
 			err := beforeHook.Handler(ctx)
@@ -442,13 +442,18 @@ func TestCSRFPlugin_HookMatcher_SafeMethods(t *testing.T) {
 			var userID *string
 			if tt.userID != "" {
 				userID = &tt.userID
-				req = req.WithContext(context.WithValue(req.Context(), models.ContextUserID, tt.userID))
+				req = req.WithContext(context.WithValue(req.Context(), models.ContextAuthActor, &models.Actor{ID: tt.userID, Type: models.ActorUser, Permissions: []string{}}))
 			}
 			ctx := &models.RequestContext{
 				Request: req,
 				Path:    tt.path,
 				Method:  tt.method,
-				UserID:  userID,
+				Actor: func() *models.Actor {
+					if userID == nil {
+						return nil
+					}
+					return &models.Actor{ID: *userID, Type: models.ActorUser, Permissions: []string{}}
+				}(),
 			}
 
 			result := beforeHook.Matcher(ctx)
@@ -647,7 +652,7 @@ func TestCSRFPlugin_UnsafeMethodWithFormToken(t *testing.T) {
 		ResponseWriter: w,
 		Path:           "/authenticated",
 		Method:         http.MethodPost,
-		UserID:         userID,
+		Actor:          principalPtr(userID),
 	}
 
 	err := beforeHook.Handler(ctx)
@@ -911,7 +916,7 @@ func TestCSRFPlugin_BeforeHookMatcherSkipsUnauthenticatedPaths(t *testing.T) {
 			ctx := &models.RequestContext{
 				Path:   tt.path,
 				Method: tt.method,
-				UserID: userID,
+				Actor:  principalPtr(userID),
 			}
 			result := beforeHook.Matcher(ctx)
 			if result != tt.expected {
@@ -998,7 +1003,7 @@ func TestCSRFPlugin_TokenGenerationRequiresAuthentication(t *testing.T) {
 				ResponseWriter: w,
 				Path:           "/authenticated-endpoint",
 				Method:         tt.method,
-				UserID:         tt.userID,
+				Actor:          principalPtr(tt.userID),
 			}
 
 			// Check if matcher allows this request to run the hook
@@ -1061,7 +1066,7 @@ func TestCSRFPlugin_UnauthenticatedEndpointsSkipValidation(t *testing.T) {
 				Request:        req,
 				ResponseWriter: w,
 				Path:           tt.path,
-				UserID:         nil, // unauthenticated
+				Actor:          nil, // unauthenticated
 			}
 
 			// Matcher should return false (skip hook) for unauthenticated paths
@@ -1152,7 +1157,7 @@ func TestCSRFPlugin_AuthenticatedUnsafeMethodStillValidates(t *testing.T) {
 				ResponseWriter: w,
 				Path:           "/api/protected",
 				Method:         tt.method,
-				UserID:         userID,
+				Actor:          principalPtr(userID),
 			}
 
 			err := beforeHook.Handler(ctx)
@@ -1176,6 +1181,14 @@ func TestCSRFPlugin_AuthenticatedUnsafeMethodStillValidates(t *testing.T) {
 // Helper function to create a string pointer
 func stringPtr(s string) *string {
 	return &s
+}
+
+func principalPtr(userID *string) *models.Actor {
+	if userID == nil {
+		return nil
+	}
+
+	return &models.Actor{ID: *userID, Type: models.ActorUser, Permissions: []string{}}
 }
 
 // TestCSRFPlugin_ScopedTokenValidation tests that CSRF token generation only happens for safe methods with auth.
@@ -1223,7 +1236,7 @@ func TestCSRFPlugin_ScopedTokenValidation(t *testing.T) {
 				Request: req,
 				Path:    tt.path,
 				Method:  tt.method,
-				UserID:  tt.userID,
+				Actor:   principalPtr(tt.userID),
 			}
 
 			result := beforeHook.Matcher(ctx)
@@ -1270,7 +1283,7 @@ func TestCSRFPlugin_MiddlewareTokenGeneration(t *testing.T) {
 		ResponseHeaders: make(http.Header),
 		Handled:         false,
 	}
-	reqCtx.UserID = &userID
+	reqCtx.SetActorInContext(&models.Actor{ID: userID, Type: models.ActorUser})
 
 	// Set the RequestContext in the request context as the router would
 	req = req.WithContext(models.NewContextWithRequestContext(req.Context(), reqCtx))
@@ -1362,7 +1375,7 @@ func TestCSRFPlugin_MiddlewareValidation(t *testing.T) {
 					ResponseHeaders: make(http.Header),
 					Handled:         false,
 				}
-				reqCtx.UserID = &userID
+				reqCtx.SetActorInContext(&models.Actor{ID: userID, Type: models.ActorUser})
 
 				// Set the RequestContext in the request context as the router would
 				req = req.WithContext(models.NewContextWithRequestContext(req.Context(), reqCtx))
@@ -1426,7 +1439,7 @@ func TestCSRFPlugin_MiddlewareSafeMethods(t *testing.T) {
 	for _, method := range safeMethods {
 		t.Run(method, func(t *testing.T) {
 			req := httptest.NewRequest(method, "/api/custom", nil)
-			req = req.WithContext(setContextValue(req.Context(), models.ContextUserID, "user-123"))
+			req = req.WithContext(setContextValue(req.Context(), models.ContextAuthActor, &models.Actor{ID: "user-123", Type: models.ActorUser, Permissions: []string{}}))
 			w := httptest.NewRecorder()
 
 			handlerCalled := false
@@ -1607,7 +1620,7 @@ func TestCSRFPlugin_TokenValidationStillRequiredWithHeaderProtection(t *testing.
 		ResponseWriter: w,
 		Method:         "POST",
 		Path:           "/api/test",
-		UserID:         stringPtr("user123"),
+		Actor:          principalPtr(stringPtr("user123")),
 	}
 
 	// Validate - should fail due to missing token, not missing headers

--- a/plugins/email-password/handlers/request_email_change_handler.go
+++ b/plugins/email-password/handlers/request_email_change_handler.go
@@ -18,7 +18,7 @@ func (h *RequestEmailChangeHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		if reqCtx.UserID == nil {
+		if reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -38,7 +38,7 @@ func (h *RequestEmailChangeHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		err := h.UseCase.RequestChange(ctx, *reqCtx.UserID, request.NewEmail, request.CallbackURL)
+		err := h.UseCase.RequestChange(ctx, reqCtx.Actor.ID, request.NewEmail, request.CallbackURL)
 		if err != nil {
 			reqCtx.SetJSONResponse(http.StatusBadRequest, map[string]any{
 				"message": err.Error(),

--- a/plugins/email-password/handlers/send_email_verification_handler.go
+++ b/plugins/email-password/handlers/send_email_verification_handler.go
@@ -18,7 +18,7 @@ func (h *SendEmailVerificationHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		if reqCtx.UserID == nil || *reqCtx.UserID == "" {
+		if reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -36,7 +36,7 @@ func (h *SendEmailVerificationHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		err := h.UseCase.Send(ctx, *reqCtx.UserID, request.CallbackURL)
+		err := h.UseCase.Send(ctx, reqCtx.Actor.ID, request.CallbackURL)
 		if err != nil {
 			reqCtx.SetJSONResponse(http.StatusInternalServerError, map[string]any{"message": err.Error()})
 			reqCtx.Handled = true

--- a/plugins/email-password/handlers/sign_in_handler.go
+++ b/plugins/email-password/handlers/sign_in_handler.go
@@ -24,7 +24,7 @@ func (h *SignInHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		if reqCtx.UserID != nil && *reqCtx.UserID != "" {
+		if reqCtx.Actor != nil && reqCtx.Actor.ID != "" {
 			if sessionID, ok := reqCtx.Values[models.ContextSessionID.String()].(string); ok && sessionID != "" {
 				existingSession, err := h.SignInUseCase.GetSessionByID(ctx, sessionID)
 				if err == nil && existingSession != nil && existingSession.ExpiresAt.After(time.Now()) {
@@ -94,7 +94,7 @@ func (h *SignInHandler) Handler() http.HandlerFunc {
 			}()
 		}
 
-		reqCtx.SetUserIDInContext(result.User.ID)
+		reqCtx.SetActorInContext(&models.Actor{ID: result.User.ID, Type: models.ActorUser})
 		reqCtx.Values[models.ContextSessionID.String()] = result.Session.ID
 		reqCtx.Values[models.ContextSessionToken.String()] = result.SessionToken
 		reqCtx.Values[models.ContextAuthSuccess.String()] = true

--- a/plugins/email-password/handlers/sign_up_handler.go
+++ b/plugins/email-password/handlers/sign_up_handler.go
@@ -70,7 +70,7 @@ func (h *SignUpHandler) Handler() http.HandlerFunc {
 			}()
 		}
 
-		reqCtx.SetUserIDInContext(result.User.ID)
+		reqCtx.SetActorInContext(&models.Actor{ID: result.User.ID, Type: models.ActorUser})
 		if h.PluginConfig.AutoSignIn {
 			reqCtx.Values[models.ContextSessionID.String()] = result.Session.ID
 			reqCtx.Values[models.ContextSessionToken.String()] = result.SessionToken

--- a/plugins/jwt/hooks.go
+++ b/plugins/jwt/hooks.go
@@ -21,7 +21,7 @@ func (id JWTHookID) String() string {
 }
 
 func (p *JWTPlugin) issueTokensHook(reqCtx *models.RequestContext) error {
-	if reqCtx.UserID == nil {
+	if reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 		return nil
 	}
 
@@ -34,15 +34,15 @@ func (p *JWTPlugin) issueTokensHook(reqCtx *models.RequestContext) error {
 		return nil
 	}
 
-	tokenPair, err := p.jwtService.GenerateTokens(context.Background(), *reqCtx.UserID, sessionID)
+	tokenPair, err := p.jwtService.GenerateTokens(context.Background(), reqCtx.Actor.ID, sessionID)
 	if err != nil {
-		p.Logger.Error("failed to generate JWT tokens", "user_id", *reqCtx.UserID, "session_id", sessionID, "error", err)
+		p.Logger.Error("failed to generate JWT tokens", "user_id", reqCtx.Actor.ID, "session_id", sessionID, "error", err)
 		return fmt.Errorf("failed to generate authentication tokens: %w", err)
 	}
 
 	expiresAt := time.Now().Add(p.pluginConfig.RefreshExpiresIn)
 	if err := p.refreshService.StoreInitialRefreshToken(reqCtx.Request.Context(), tokenPair.RefreshToken, sessionID, expiresAt); err != nil {
-		p.Logger.Error("failed to store refresh token", "user_id", *reqCtx.UserID, "session_id", sessionID, "error", err)
+		p.Logger.Error("failed to store refresh token", "user_id", reqCtx.Actor.ID, "session_id", sessionID, "error", err)
 		return fmt.Errorf("failed to store refresh token: %w", err)
 	}
 
@@ -53,7 +53,7 @@ func (p *JWTPlugin) issueTokensHook(reqCtx *models.RequestContext) error {
 }
 
 func (p *JWTPlugin) respondHook(reqCtx *models.RequestContext) error {
-	if reqCtx.UserID == nil {
+	if reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 		return nil
 	}
 

--- a/plugins/magic-link/handlers/exchange_handler.go
+++ b/plugins/magic-link/handlers/exchange_handler.go
@@ -44,7 +44,7 @@ func (h *ExchangeHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		reqCtx.SetUserIDInContext(result.User.ID)
+		reqCtx.SetActorInContext(&models.Actor{ID: result.User.ID, Type: models.ActorUser})
 		reqCtx.Values[models.ContextSessionID.String()] = result.Session.ID
 		reqCtx.Values[models.ContextSessionToken.String()] = result.SessionToken
 		reqCtx.Values[models.ContextAuthSuccess.String()] = true

--- a/plugins/magic-link/handlers/exchange_handler_test.go
+++ b/plugins/magic-link/handlers/exchange_handler_test.go
@@ -34,8 +34,8 @@ func TestExchangeHandler(t *testing.T) {
 				if reqCtx.ResponseStatus != http.StatusOK {
 					t.Fatalf("expected status OK, got %d", reqCtx.ResponseStatus)
 				}
-				if reqCtx.UserID == nil || *reqCtx.UserID != "user-123" {
-					t.Fatalf("expected user id to be set, got %v", reqCtx.UserID)
+				if reqCtx.Actor == nil || reqCtx.Actor.ID != "user-123" {
+					t.Fatalf("expected user id to be set, got %v", reqCtx.Actor)
 				}
 				if reqCtx.Values[models.ContextSessionID.String()] != "sess-456" {
 					t.Fatalf("expected session id in context, got %v", reqCtx.Values[models.ContextSessionID.String()])

--- a/plugins/magic-link/handlers/sign_in_handler.go
+++ b/plugins/magic-link/handlers/sign_in_handler.go
@@ -18,7 +18,7 @@ func (h *SignInHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		if reqCtx.UserID != nil && *reqCtx.UserID != "" {
+		if reqCtx.Actor != nil && reqCtx.Actor.ID != "" {
 			reqCtx.SetJSONResponse(http.StatusBadRequest, map[string]any{
 				"message": "you're already authenticated.",
 			})

--- a/plugins/magic-link/handlers/sign_in_handler_test.go
+++ b/plugins/magic-link/handlers/sign_in_handler_test.go
@@ -88,7 +88,7 @@ func TestSignInHandler(t *testing.T) {
 			name:        "already authenticated returns bad request",
 			requestBody: internaltests.MarshalToJSON(t, types.SignInRequest{Email: "test@example.com"}),
 			setup: func(t *testing.T, reqCtx *models.RequestContext, userService *internaltests.MockUserService, accountService *internaltests.MockAccountService, tokenService *internaltests.MockTokenService, verificationService *internaltests.MockVerificationService) {
-				reqCtx.UserID = &name
+				reqCtx.SetActorInContext(&models.Actor{ID: name, Type: models.ActorUser})
 			},
 			assertResult: func(t *testing.T, reqCtx *models.RequestContext) {
 				if reqCtx.ResponseStatus != http.StatusBadRequest {

--- a/plugins/oauth2/handlers/callback_handler.go
+++ b/plugins/oauth2/handlers/callback_handler.go
@@ -68,7 +68,7 @@ func (h *CallbackHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		if reqCtx.UserID != nil && *reqCtx.UserID != "" {
+		if reqCtx.Actor != nil && reqCtx.Actor.ID != "" {
 			if sessionID, ok := reqCtx.Values[models.ContextSessionID.String()].(string); ok && sessionID != "" {
 				existingSession, err := h.UseCase.GetSessionByID(ctx, sessionID)
 				if err == nil && existingSession != nil && existingSession.ExpiresAt.After(time.Now()) {
@@ -125,7 +125,7 @@ func (h *CallbackHandler) Handler() http.HandlerFunc {
 			MaxAge:   -1,
 		})
 
-		reqCtx.SetUserIDInContext(result.User.ID)
+		reqCtx.SetActorInContext(&models.Actor{ID: result.User.ID, Type: models.ActorUser})
 		reqCtx.Values[models.ContextSessionID.String()] = result.Session.ID
 		reqCtx.Values[models.ContextSessionToken.String()] = result.SessionToken
 		reqCtx.Values[models.ContextAuthSuccess.String()] = true

--- a/plugins/organizations/api.go
+++ b/plugins/organizations/api.go
@@ -3,6 +3,7 @@ package organizations
 import (
 	"context"
 
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/services"
 	"github.com/Authula/authula/plugins/organizations/types"
 )
@@ -27,110 +28,110 @@ func BuildAPI(plugin *OrganizationsPlugin) *API {
 
 // Organizations
 
-func (a *API) CreateOrganization(ctx context.Context, actorUserID string, request types.CreateOrganizationRequest) (*types.Organization, error) {
-	return a.organizationService.CreateOrganization(ctx, actorUserID, request)
+func (a *API) CreateOrganization(ctx context.Context, actor models.Actor, request types.CreateOrganizationRequest) (*types.Organization, error) {
+	return a.organizationService.CreateOrganization(ctx, actor, request)
 }
 
-func (a *API) GetAllOrganizations(ctx context.Context, actorUserID string) ([]types.Organization, error) {
-	return a.organizationService.GetAllOrganizations(ctx, actorUserID)
+func (a *API) GetAllOrganizations(ctx context.Context, actor models.Actor) ([]types.Organization, error) {
+	return a.organizationService.GetAllOrganizations(ctx, actor)
 }
 
-func (a *API) GetOrganizationByID(ctx context.Context, actorUserID string, organizationID string) (*types.Organization, error) {
-	return a.organizationService.GetOrganizationByID(ctx, actorUserID, organizationID)
+func (a *API) GetOrganizationByID(ctx context.Context, actor models.Actor, organizationID string) (*types.Organization, error) {
+	return a.organizationService.GetOrganizationByID(ctx, actor, organizationID)
 }
 
-func (a *API) UpdateOrganization(ctx context.Context, actorUserID string, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error) {
-	return a.organizationService.UpdateOrganization(ctx, actorUserID, organizationID, request)
+func (a *API) UpdateOrganization(ctx context.Context, actor models.Actor, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error) {
+	return a.organizationService.UpdateOrganization(ctx, actor, organizationID, request)
 }
 
-func (a *API) DeleteOrganization(ctx context.Context, actorUserID string, organizationID string) error {
-	return a.organizationService.DeleteOrganization(ctx, actorUserID, organizationID)
+func (a *API) DeleteOrganization(ctx context.Context, actor models.Actor, organizationID string) error {
+	return a.organizationService.DeleteOrganization(ctx, actor, organizationID)
 }
 
 // Invitations
 
-func (a *API) CreateInvitation(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error) {
-	return a.invitationService.CreateOrganizationInvitation(ctx, actorUserID, organizationID, request)
+func (a *API) CreateInvitation(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error) {
+	return a.invitationService.CreateOrganizationInvitation(ctx, actor, organizationID, request)
 }
 
-func (a *API) GetInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	return a.invitationService.GetOrganizationInvitation(ctx, actorUserID, organizationID, invitationID)
+func (a *API) GetInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	return a.invitationService.GetOrganizationInvitation(ctx, actor, organizationID, invitationID)
 }
 
-func (a *API) GetAllInvitations(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationInvitation, error) {
-	return a.invitationService.GetAllOrganizationInvitations(ctx, actorUserID, organizationID)
+func (a *API) GetAllInvitations(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationInvitation, error) {
+	return a.invitationService.GetAllOrganizationInvitations(ctx, actor, organizationID)
 }
 
-func (a *API) RevokeInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	return a.invitationService.RevokeOrganizationInvitation(ctx, actorUserID, organizationID, invitationID)
+func (a *API) RevokeInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	return a.invitationService.RevokeOrganizationInvitation(ctx, actor, organizationID, invitationID)
 }
 
-func (a *API) AcceptInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	return a.invitationService.AcceptOrganizationInvitation(ctx, actorUserID, organizationID, invitationID)
+func (a *API) AcceptInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	return a.invitationService.AcceptOrganizationInvitation(ctx, actor, organizationID, invitationID)
 }
 
-func (a *API) RejectInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	return a.invitationService.RejectOrganizationInvitation(ctx, actorUserID, organizationID, invitationID)
+func (a *API) RejectInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	return a.invitationService.RejectOrganizationInvitation(ctx, actor, organizationID, invitationID)
 }
 
 // Members
 
-func (a *API) AddMember(ctx context.Context, actorUserID string, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error) {
-	return a.memberService.AddMember(ctx, actorUserID, organizationID, request)
+func (a *API) AddMember(ctx context.Context, actor models.Actor, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error) {
+	return a.memberService.AddMember(ctx, actor, organizationID, request)
 }
 
-func (a *API) GetAllMembers(ctx context.Context, actorUserID string, organizationID string, page int, limit int) ([]types.OrganizationMember, error) {
-	return a.memberService.GetAllMembers(ctx, actorUserID, organizationID, page, limit)
+func (a *API) GetAllMembers(ctx context.Context, actor models.Actor, organizationID string, page int, limit int) ([]types.OrganizationMember, error) {
+	return a.memberService.GetAllMembers(ctx, actor, organizationID, page, limit)
 }
 
-func (a *API) GetMember(ctx context.Context, actorUserID string, organizationID string, memberID string) (*types.OrganizationMember, error) {
-	return a.memberService.GetMember(ctx, actorUserID, organizationID, memberID)
+func (a *API) GetMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) (*types.OrganizationMember, error) {
+	return a.memberService.GetMember(ctx, actor, organizationID, memberID)
 }
 
-func (a *API) UpdateMember(ctx context.Context, actorUserID string, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error) {
-	return a.memberService.UpdateMember(ctx, actorUserID, organizationID, memberID, request)
+func (a *API) UpdateMember(ctx context.Context, actor models.Actor, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error) {
+	return a.memberService.UpdateMember(ctx, actor, organizationID, memberID, request)
 }
 
-func (a *API) RemoveMember(ctx context.Context, actorUserID string, organizationID string, memberID string) error {
-	return a.memberService.RemoveMember(ctx, actorUserID, organizationID, memberID)
+func (a *API) RemoveMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) error {
+	return a.memberService.RemoveMember(ctx, actor, organizationID, memberID)
 }
 
 // Teams
 
-func (a *API) CreateTeam(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
-	return a.teamService.CreateTeam(ctx, actorUserID, organizationID, request)
+func (a *API) CreateTeam(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
+	return a.teamService.CreateTeam(ctx, actor, organizationID, request)
 }
 
-func (a *API) GetAllTeams(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationTeam, error) {
-	return a.teamService.GetAllTeams(ctx, actorUserID, organizationID)
+func (a *API) GetAllTeams(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationTeam, error) {
+	return a.teamService.GetAllTeams(ctx, actor, organizationID)
 }
 
-func (a *API) GetTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) (*types.OrganizationTeam, error) {
-	return a.teamService.GetTeam(ctx, actorUserID, organizationID, teamID)
+func (a *API) GetTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) (*types.OrganizationTeam, error) {
+	return a.teamService.GetTeam(ctx, actor, organizationID, teamID)
 }
 
-func (a *API) UpdateTeam(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
-	return a.teamService.UpdateTeam(ctx, actorUserID, organizationID, teamID, request)
+func (a *API) UpdateTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
+	return a.teamService.UpdateTeam(ctx, actor, organizationID, teamID, request)
 }
 
-func (a *API) DeleteTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) error {
-	return a.teamService.DeleteTeam(ctx, actorUserID, organizationID, teamID)
+func (a *API) DeleteTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) error {
+	return a.teamService.DeleteTeam(ctx, actor, organizationID, teamID)
 }
 
 // Team Members
 
-func (a *API) AddTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error) {
-	return a.teamMemberService.AddTeamMember(ctx, actorUserID, organizationID, teamID, request)
+func (a *API) AddTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error) {
+	return a.teamMemberService.AddTeamMember(ctx, actor, organizationID, teamID, request)
 }
 
-func (a *API) GetAllTeamMembers(ctx context.Context, actorUserID string, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error) {
-	return a.teamMemberService.GetAllTeamMembers(ctx, actorUserID, organizationID, teamID, page, limit)
+func (a *API) GetAllTeamMembers(ctx context.Context, actor models.Actor, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error) {
+	return a.teamMemberService.GetAllTeamMembers(ctx, actor, organizationID, teamID, page, limit)
 }
 
-func (a *API) GetTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error) {
-	return a.teamMemberService.GetTeamMember(ctx, actorUserID, organizationID, teamID, memberID)
+func (a *API) GetTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error) {
+	return a.teamMemberService.GetTeamMember(ctx, actor, organizationID, teamID, memberID)
 }
 
-func (a *API) RemoveTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) error {
-	return a.teamMemberService.RemoveTeamMember(ctx, actorUserID, organizationID, teamID, memberID)
+func (a *API) RemoveTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) error {
+	return a.teamMemberService.RemoveTeamMember(ctx, actor, organizationID, teamID, memberID)
 }

--- a/plugins/organizations/handlers/organization_handlers.go
+++ b/plugins/organizations/handlers/organization_handlers.go
@@ -19,8 +19,8 @@ func (h *CreateOrganizationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -38,14 +38,14 @@ func (h *CreateOrganizationHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		organization, err := h.OrgService.CreateOrganization(ctx, userID, request)
+		organization, err := h.OrgService.CreateOrganization(ctx, *actor, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
 		}
 
 		reqCtx.Values[models.ContextAccessControlAssignRole.String()] = &models.AccessControlAssignRoleContext{
-			UserID:         userID,
+			UserID:         actor.ID,
 			RoleName:       request.Role,
 			AssignerUserID: nil,
 		}
@@ -63,14 +63,14 @@ func (h *GetAllOrganizationsHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
 		}
 
-		organizations, err := h.OrgService.GetAllOrganizations(ctx, userID)
+		organizations, err := h.OrgService.GetAllOrganizations(ctx, *actor)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -89,15 +89,15 @@ func (h *GetOrganizationByIDHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
 		}
 
 		organizationID := r.PathValue("organization_id")
-		organization, err := h.OrgService.GetOrganizationByID(ctx, userID, organizationID)
+		organization, err := h.OrgService.GetOrganizationByID(ctx, *actor, organizationID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -116,8 +116,8 @@ func (h *UpdateOrganizationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -136,7 +136,7 @@ func (h *UpdateOrganizationHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		organization, err := h.OrgService.UpdateOrganization(ctx, userID, organizationID, request)
+		organization, err := h.OrgService.UpdateOrganization(ctx, *actor, organizationID, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -155,15 +155,15 @@ func (h *DeleteOrganizationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
 		}
 
 		organizationID := r.PathValue("organization_id")
-		if err := h.OrgService.DeleteOrganization(ctx, userID, organizationID); err != nil {
+		if err := h.OrgService.DeleteOrganization(ctx, *actor, organizationID); err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
 		}

--- a/plugins/organizations/handlers/organization_invitation_handlers.go
+++ b/plugins/organizations/handlers/organization_invitation_handlers.go
@@ -19,8 +19,8 @@ func (h *CreateOrganizationInvitationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -40,7 +40,7 @@ func (h *CreateOrganizationInvitationHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		invitation, err := h.OrgInvitationService.CreateOrganizationInvitation(ctx, userID, organizationID, request)
+		invitation, err := h.OrgInvitationService.CreateOrganizationInvitation(ctx, *actor, organizationID, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -59,15 +59,15 @@ func (h *GetAllOrganizationInvitationsHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
 		}
 
 		organizationID := r.PathValue("organization_id")
-		invitations, err := h.OrgInvitationService.GetAllOrganizationInvitations(ctx, userID, organizationID)
+		invitations, err := h.OrgInvitationService.GetAllOrganizationInvitations(ctx, *actor, organizationID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -86,8 +86,8 @@ func (h *GetOrganizationInvitationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -95,7 +95,7 @@ func (h *GetOrganizationInvitationHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		invitationID := r.PathValue("invitation_id")
-		invitation, err := h.OrgInvitationService.GetOrganizationInvitation(ctx, userID, organizationID, invitationID)
+		invitation, err := h.OrgInvitationService.GetOrganizationInvitation(ctx, *actor, organizationID, invitationID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -114,8 +114,8 @@ func (h *RevokeOrganizationInvitationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -123,7 +123,7 @@ func (h *RevokeOrganizationInvitationHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		invitationID := r.PathValue("invitation_id")
-		invitation, err := h.OrgInvitationService.RevokeOrganizationInvitation(ctx, userID, organizationID, invitationID)
+		invitation, err := h.OrgInvitationService.RevokeOrganizationInvitation(ctx, *actor, organizationID, invitationID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -142,8 +142,8 @@ func (h *AcceptOrganizationInvitationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -151,14 +151,14 @@ func (h *AcceptOrganizationInvitationHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		invitationID := r.PathValue("invitation_id")
-		invitation, err := h.OrgInvitationService.AcceptOrganizationInvitation(ctx, userID, organizationID, invitationID)
+		invitation, err := h.OrgInvitationService.AcceptOrganizationInvitation(ctx, *actor, organizationID, invitationID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
 		}
 
 		reqCtx.Values[models.ContextAccessControlAssignRole.String()] = &models.AccessControlAssignRoleContext{
-			UserID:         userID,
+			UserID:         actor.ID,
 			RoleName:       invitation.Role,
 			AssignerUserID: &invitation.InviterID,
 		}
@@ -189,8 +189,8 @@ func (h *RejectOrganizationInvitationHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -198,7 +198,7 @@ func (h *RejectOrganizationInvitationHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		invitationID := r.PathValue("invitation_id")
-		invitation, err := h.OrgInvitationService.RejectOrganizationInvitation(ctx, userID, organizationID, invitationID)
+		invitation, err := h.OrgInvitationService.RejectOrganizationInvitation(ctx, *actor, organizationID, invitationID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return

--- a/plugins/organizations/handlers/organization_member_handlers.go
+++ b/plugins/organizations/handlers/organization_member_handlers.go
@@ -19,8 +19,8 @@ func (h *AddOrganizationMemberHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -40,7 +40,7 @@ func (h *AddOrganizationMemberHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		member, err := h.OrgMemberService.AddMember(ctx, userID, organizationID, request)
+		member, err := h.OrgMemberService.AddMember(ctx, *actor, organizationID, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -49,7 +49,7 @@ func (h *AddOrganizationMemberHandler) Handle() http.HandlerFunc {
 		reqCtx.Values[models.ContextAccessControlAssignRole.String()] = &models.AccessControlAssignRoleContext{
 			UserID:         request.UserID,
 			RoleName:       request.Role,
-			AssignerUserID: &userID,
+			AssignerUserID: &actor.ID,
 		}
 
 		reqCtx.SetJSONResponse(http.StatusCreated, member)
@@ -65,8 +65,8 @@ func (h *GetAllOrganizationMembersHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -75,7 +75,7 @@ func (h *GetAllOrganizationMembersHandler) Handle() http.HandlerFunc {
 		organizationID := r.PathValue("organization_id")
 		page := util.GetQueryInt(r, "page", 1)
 		limit := util.GetQueryInt(r, "limit", 10)
-		members, err := h.OrgMemberService.GetAllMembers(ctx, userID, organizationID, page, limit)
+		members, err := h.OrgMemberService.GetAllMembers(ctx, *actor, organizationID, page, limit)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -94,8 +94,8 @@ func (h *GetOrganizationMemberHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -103,7 +103,7 @@ func (h *GetOrganizationMemberHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		memberID := r.PathValue("member_id")
-		member, err := h.OrgMemberService.GetMember(ctx, userID, organizationID, memberID)
+		member, err := h.OrgMemberService.GetMember(ctx, *actor, organizationID, memberID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -122,8 +122,8 @@ func (h *UpdateOrganizationMemberHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -144,7 +144,7 @@ func (h *UpdateOrganizationMemberHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		member, err := h.OrgMemberService.UpdateMember(ctx, userID, organizationID, memberID, request)
+		member, err := h.OrgMemberService.UpdateMember(ctx, *actor, organizationID, memberID, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -153,7 +153,7 @@ func (h *UpdateOrganizationMemberHandler) Handle() http.HandlerFunc {
 		reqCtx.Values[models.ContextAccessControlAssignRole.String()] = &models.AccessControlAssignRoleContext{
 			UserID:         member.UserID,
 			RoleName:       request.Role,
-			AssignerUserID: &userID,
+			AssignerUserID: &actor.ID,
 		}
 
 		reqCtx.SetJSONResponse(http.StatusOK, member)
@@ -169,8 +169,8 @@ func (h *DeleteOrganizationMemberHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -178,7 +178,7 @@ func (h *DeleteOrganizationMemberHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		memberID := r.PathValue("member_id")
-		if err := h.OrgMemberService.RemoveMember(ctx, userID, organizationID, memberID); err != nil {
+		if err := h.OrgMemberService.RemoveMember(ctx, *actor, organizationID, memberID); err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
 		}

--- a/plugins/organizations/handlers/organization_member_handlers_test.go
+++ b/plugins/organizations/handlers/organization_member_handlers_test.go
@@ -23,7 +23,7 @@ type organizationMemberHandlerFixture struct {
 
 type organizationMemberHandlerCase struct {
 	name            string
-	userID          *string
+	actor           models.Actor
 	body            []byte
 	organizationID  string
 	memberID        string
@@ -37,10 +37,10 @@ func newOrganizationMemberHandlerFixture() *organizationMemberHandlerFixture {
 	return &organizationMemberHandlerFixture{service: &orgtests.MockOrganizationMemberService{}}
 }
 
-func (f *organizationMemberHandlerFixture) newRequest(t *testing.T, method, path string, body []byte, userID *string, organizationID, memberID string) (*http.Request, *httptest.ResponseRecorder, *models.RequestContext) {
+func (f *organizationMemberHandlerFixture) newRequest(t *testing.T, method, path string, body []byte, actor *models.Actor, organizationID, memberID string) (*http.Request, *httptest.ResponseRecorder, *models.RequestContext) {
 	t.Helper()
 
-	req, w, reqCtx := internaltests.NewHandlerRequest(t, method, path, body, userID)
+	req, w, reqCtx := internaltests.NewHandlerRequest(t, method, path, body, actor)
 	if organizationID != "" {
 		req.SetPathValue("organization_id", organizationID)
 	}
@@ -63,7 +63,7 @@ func runOrganizationMemberHandlerCases(t *testing.T, method, path string, buildH
 			}
 
 			handler := buildHandler(fixture)
-			req, w, reqCtx := fixture.newRequest(t, method, path, tt.body, tt.userID, tt.organizationID, tt.memberID)
+			req, w, reqCtx := fixture.newRequest(t, method, path, tt.body, &tt.actor, tt.organizationID, tt.memberID)
 			handler.ServeHTTP(w, req)
 
 			assert.Equal(t, tt.expectedStatus, reqCtx.ResponseStatus)
@@ -93,7 +93,7 @@ func TestAddOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:            "invalid_json",
-			userID:          new("user-1"),
+			actor:           models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:  "org-1",
 			body:            []byte("{"),
 			expectedStatus:  http.StatusUnprocessableEntity,
@@ -101,7 +101,7 @@ func TestAddOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "service_error",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			body:           internaltests.MarshalToJSON(t, orgtypes.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"}),
 			prepare: func(fixture *organizationMemberHandlerFixture) {
@@ -112,7 +112,7 @@ func TestAddOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "quota_exceeded",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			body:           internaltests.MarshalToJSON(t, orgtypes.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"}),
 			prepare: func(fixture *organizationMemberHandlerFixture) {
@@ -123,7 +123,7 @@ func TestAddOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "success_with_role_assignment",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			body:           internaltests.MarshalToJSON(t, orgtypes.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"}),
 			prepare: func(fixture *organizationMemberHandlerFixture) {
@@ -161,7 +161,7 @@ func TestGetAllOrganizationMembersHandler(t *testing.T) {
 		},
 		{
 			name:           "service_error",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			prepare: func(fixture *organizationMemberHandlerFixture) {
 				fixture.service.On("GetAllMembers", mock.Anything, "user-1", "org-1", 1, 10).Return(([]orgtypes.OrganizationMember)(nil), errors.New("some error")).Once()
@@ -171,7 +171,7 @@ func TestGetAllOrganizationMembersHandler(t *testing.T) {
 		},
 		{
 			name:           "success",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			prepare: func(fixture *organizationMemberHandlerFixture) {
 				fixture.service.On("GetAllMembers", mock.Anything, "user-1", "org-1", 1, 10).Return([]orgtypes.OrganizationMember{{ID: "mem-1", OrganizationID: "org-1", UserID: "user-2", Role: "member"}}, nil).Once()
@@ -201,7 +201,7 @@ func TestGetOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "not_found",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			prepare: func(fixture *organizationMemberHandlerFixture) {
@@ -212,7 +212,7 @@ func TestGetOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "success",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			prepare: func(fixture *organizationMemberHandlerFixture) {
@@ -244,7 +244,7 @@ func TestUpdateOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:            "invalid_json",
-			userID:          new("user-1"),
+			actor:           models.Actor{ID: "user-1"},
 			organizationID:  "org-1",
 			memberID:        "mem-1",
 			body:            []byte("{"),
@@ -253,7 +253,7 @@ func TestUpdateOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1"},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			body:           internaltests.MarshalToJSON(t, orgtypes.UpdateOrganizationMemberRequest{Role: "admin"}),
@@ -265,7 +265,7 @@ func TestUpdateOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "success_with_role_assignment",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1"},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			body:           internaltests.MarshalToJSON(t, orgtypes.UpdateOrganizationMemberRequest{Role: "admin"}),
@@ -303,7 +303,7 @@ func TestDeleteOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "service_error",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1"},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			prepare: func(fixture *organizationMemberHandlerFixture) {
@@ -314,7 +314,7 @@ func TestDeleteOrganizationMemberHandler(t *testing.T) {
 		},
 		{
 			name:           "success",
-			userID:         new("user-1"),
+			actor:          models.Actor{ID: "user-1"},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			prepare: func(fixture *organizationMemberHandlerFixture) {

--- a/plugins/organizations/handlers/organization_team_handlers.go
+++ b/plugins/organizations/handlers/organization_team_handlers.go
@@ -19,8 +19,8 @@ func (h *CreateOrganizationTeamHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -40,7 +40,7 @@ func (h *CreateOrganizationTeamHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		team, err := h.OrgTeamService.CreateTeam(ctx, userID, organizationID, request)
+		team, err := h.OrgTeamService.CreateTeam(ctx, *actor, organizationID, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -59,15 +59,15 @@ func (h *GetAllOrganizationTeamsHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
 		}
 
 		organizationID := r.PathValue("organization_id")
-		teams, err := h.OrgTeamService.GetAllTeams(ctx, userID, organizationID)
+		teams, err := h.OrgTeamService.GetAllTeams(ctx, *actor, organizationID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -86,8 +86,8 @@ func (h *GetOrganizationTeamHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -95,7 +95,7 @@ func (h *GetOrganizationTeamHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		teamID := r.PathValue("team_id")
-		team, err := h.OrgTeamService.GetTeam(ctx, userID, organizationID, teamID)
+		team, err := h.OrgTeamService.GetTeam(ctx, *actor, organizationID, teamID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -114,8 +114,8 @@ func (h *UpdateOrganizationTeamHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -136,7 +136,7 @@ func (h *UpdateOrganizationTeamHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		team, err := h.OrgTeamService.UpdateTeam(ctx, userID, organizationID, teamID, request)
+		team, err := h.OrgTeamService.UpdateTeam(ctx, *actor, organizationID, teamID, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -155,8 +155,8 @@ func (h *DeleteOrganizationTeamHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -164,7 +164,7 @@ func (h *DeleteOrganizationTeamHandler) Handle() http.HandlerFunc {
 
 		organizationID := r.PathValue("organization_id")
 		teamID := r.PathValue("team_id")
-		if err := h.OrgTeamService.DeleteTeam(ctx, userID, organizationID, teamID); err != nil {
+		if err := h.OrgTeamService.DeleteTeam(ctx, *actor, organizationID, teamID); err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
 		}

--- a/plugins/organizations/handlers/organization_team_member_handlers.go
+++ b/plugins/organizations/handlers/organization_team_member_handlers.go
@@ -19,8 +19,8 @@ func (h *AddOrganizationTeamMemberHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -41,7 +41,7 @@ func (h *AddOrganizationTeamMemberHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		teamMember, err := h.OrgTeamMemberService.AddTeamMember(ctx, userID, organizationID, teamID, request)
+		teamMember, err := h.OrgTeamMemberService.AddTeamMember(ctx, *actor, organizationID, teamID, request)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -60,8 +60,8 @@ func (h *GetAllOrganizationTeamMembersHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -71,7 +71,7 @@ func (h *GetAllOrganizationTeamMembersHandler) Handle() http.HandlerFunc {
 		teamID := r.PathValue("team_id")
 		page := util.GetQueryInt(r, "page", 1)
 		limit := util.GetQueryInt(r, "limit", 10)
-		teamMembers, err := h.OrgTeamMemberService.GetAllTeamMembers(ctx, userID, organizationID, teamID, page, limit)
+		teamMembers, err := h.OrgTeamMemberService.GetAllTeamMembers(ctx, *actor, organizationID, teamID, page, limit)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -90,8 +90,8 @@ func (h *GetOrganizationTeamMemberHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -100,7 +100,7 @@ func (h *GetOrganizationTeamMemberHandler) Handle() http.HandlerFunc {
 		organizationID := r.PathValue("organization_id")
 		teamID := r.PathValue("team_id")
 		memberID := r.PathValue("member_id")
-		teamMember, err := h.OrgTeamMemberService.GetTeamMember(ctx, userID, organizationID, teamID, memberID)
+		teamMember, err := h.OrgTeamMemberService.GetTeamMember(ctx, *actor, organizationID, teamID, memberID)
 		if err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
@@ -119,8 +119,8 @@ func (h *DeleteOrganizationTeamMemberHandler) Handle() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		actor, ok := models.GetActorFromContext(ctx)
+		if !ok || actor == nil || actor.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{"message": "Unauthorized"})
 			reqCtx.Handled = true
 			return
@@ -129,7 +129,7 @@ func (h *DeleteOrganizationTeamMemberHandler) Handle() http.HandlerFunc {
 		organizationID := r.PathValue("organization_id")
 		teamID := r.PathValue("team_id")
 		memberID := r.PathValue("member_id")
-		if err := h.OrgTeamMemberService.RemoveTeamMember(ctx, userID, organizationID, teamID, memberID); err != nil {
+		if err := h.OrgTeamMemberService.RemoveTeamMember(ctx, *actor, organizationID, teamID, memberID); err != nil {
 			orgconstants.HandleError(err, reqCtx)
 			return
 		}

--- a/plugins/organizations/services/interfaces.go
+++ b/plugins/organizations/services/interfaces.go
@@ -3,45 +3,46 @@ package services
 import (
 	"context"
 
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/types"
 )
 
 type OrganizationService interface {
-	CreateOrganization(ctx context.Context, actorUserID string, request types.CreateOrganizationRequest) (*types.Organization, error)
-	GetAllOrganizations(ctx context.Context, actorUserID string) ([]types.Organization, error)
-	GetOrganizationByID(ctx context.Context, actorUserID string, organizationID string) (*types.Organization, error)
-	UpdateOrganization(ctx context.Context, actorUserID string, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error)
-	DeleteOrganization(ctx context.Context, actorUserID string, organizationID string) error
+	CreateOrganization(ctx context.Context, actor models.Actor, request types.CreateOrganizationRequest) (*types.Organization, error)
+	GetAllOrganizations(ctx context.Context, actor models.Actor) ([]types.Organization, error)
+	GetOrganizationByID(ctx context.Context, actor models.Actor, organizationID string) (*types.Organization, error)
+	UpdateOrganization(ctx context.Context, actor models.Actor, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error)
+	DeleteOrganization(ctx context.Context, actor models.Actor, organizationID string) error
 }
 
 type OrganizationInvitationService interface {
-	CreateOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error)
-	GetOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
-	GetAllOrganizationInvitations(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationInvitation, error)
-	RevokeOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
-	AcceptOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
-	RejectOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
+	CreateOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error)
+	GetOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
+	GetAllOrganizationInvitations(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationInvitation, error)
+	RevokeOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
+	AcceptOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
+	RejectOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error)
 }
 
 type OrganizationMemberService interface {
-	AddMember(ctx context.Context, actorUserID string, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error)
-	GetAllMembers(ctx context.Context, actorUserID string, organizationID string, page int, limit int) ([]types.OrganizationMember, error)
-	GetMember(ctx context.Context, actorUserID string, organizationID string, memberID string) (*types.OrganizationMember, error)
-	UpdateMember(ctx context.Context, actorUserID string, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error)
-	RemoveMember(ctx context.Context, actorUserID string, organizationID string, memberID string) error
+	AddMember(ctx context.Context, actor models.Actor, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error)
+	GetAllMembers(ctx context.Context, actor models.Actor, organizationID string, page int, limit int) ([]types.OrganizationMember, error)
+	GetMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) (*types.OrganizationMember, error)
+	UpdateMember(ctx context.Context, actor models.Actor, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error)
+	RemoveMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) error
 }
 
 type OrganizationTeamService interface {
-	CreateTeam(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error)
-	GetAllTeams(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationTeam, error)
-	GetTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) (*types.OrganizationTeam, error)
-	UpdateTeam(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error)
-	DeleteTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) error
+	CreateTeam(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error)
+	GetAllTeams(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationTeam, error)
+	GetTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) (*types.OrganizationTeam, error)
+	UpdateTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error)
+	DeleteTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) error
 }
 
 type OrganizationTeamMemberService interface {
-	AddTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error)
-	GetAllTeamMembers(ctx context.Context, actorUserID string, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error)
-	GetTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error)
-	RemoveTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) error
+	AddTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error)
+	GetAllTeamMembers(ctx context.Context, actor models.Actor, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error)
+	GetTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error)
+	RemoveTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) error
 }

--- a/plugins/organizations/services/organization_invitation_service.go
+++ b/plugins/organizations/services/organization_invitation_service.go
@@ -70,14 +70,14 @@ func NewOrganizationInvitationService(
 	}
 }
 
-func (s *organizationInvitationService) CreateOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error) {
+func (s *organizationInvitationService) CreateOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error) {
 	reqCtx, _ := models.GetRequestContext(ctx)
 
-	if actorUserID == "" || organizationID == "" {
+	if actor.ID == "" || organizationID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
-	organization, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID)
+	organization, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (s *organizationInvitationService) CreateOrganizationInvitation(ctx context
 		return nil, internalerrors.ErrUnprocessableEntity
 	}
 
-	validatedRoleAssignment, err := s.accessControlService.ValidateRoleAssignment(ctx, role, &actorUserID)
+	validatedRoleAssignment, err := s.accessControlService.ValidateRoleAssignment(ctx, role, &actor.ID)
 	if err != nil {
 		if err.Error() == internalerrors.ErrForbidden.Error() {
 			return nil, internalerrors.ErrForbidden
@@ -132,7 +132,7 @@ func (s *organizationInvitationService) CreateOrganizationInvitation(ctx context
 		invitation := &types.OrganizationInvitation{
 			ID:             util.GenerateUUID(),
 			Email:          request.Email,
-			InviterID:      actorUserID,
+			InviterID:      actor.ID,
 			OrganizationID: organizationID,
 			Role:           role,
 			Status:         types.OrganizationInvitationStatusPending,
@@ -157,7 +157,7 @@ func (s *organizationInvitationService) CreateOrganizationInvitation(ctx context
 	callbackHandled := false
 
 	if s.pluginConfig.SendOrganizationInvitationEmail != nil {
-		inviter, err := s.userService.GetByID(ctx, actorUserID)
+		inviter, err := s.userService.GetByID(ctx, actor.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -254,12 +254,12 @@ func (s *organizationInvitationService) publishOrganizationInvitationCreatedEven
 	})
 }
 
-func (s *organizationInvitationService) GetAllOrganizationInvitations(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationInvitation, error) {
-	if actorUserID == "" || organizationID == "" {
+func (s *organizationInvitationService) GetAllOrganizationInvitations(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationInvitation, error) {
+	if actor.ID == "" || organizationID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
-	_, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID)
+	_, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -272,12 +272,12 @@ func (s *organizationInvitationService) GetAllOrganizationInvitations(ctx contex
 	return invitations, nil
 }
 
-func (s *organizationInvitationService) GetOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	if actorUserID == "" || organizationID == "" || invitationID == "" {
+func (s *organizationInvitationService) GetOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	if actor.ID == "" || organizationID == "" || invitationID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
-	_, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID)
+	_, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -293,12 +293,12 @@ func (s *organizationInvitationService) GetOrganizationInvitation(ctx context.Co
 	return invitation, nil
 }
 
-func (s *organizationInvitationService) RevokeOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	if actorUserID == "" || organizationID == "" || invitationID == "" {
+func (s *organizationInvitationService) RevokeOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	if actor.ID == "" || organizationID == "" || invitationID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
-	_, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID)
+	_, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -326,12 +326,12 @@ func (s *organizationInvitationService) RevokeOrganizationInvitation(ctx context
 
 	return updated, nil
 }
-func (s *organizationInvitationService) AcceptOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	if actorUserID == "" || organizationID == "" || invitationID == "" {
+func (s *organizationInvitationService) AcceptOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	if actor.ID == "" || organizationID == "" || invitationID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
-	user, err := s.serviceUtils.ensureEmailVerifiedForInvitationAcceptance(ctx, s.userService, actorUserID, s.pluginConfig.RequireEmailVerifiedOnInvitation)
+	user, err := s.serviceUtils.ensureEmailVerifiedForInvitationAcceptance(ctx, s.userService, actor.ID, s.pluginConfig.RequireEmailVerifiedOnInvitation)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (s *organizationInvitationService) AcceptOrganizationInvitation(ctx context
 		return nil, internalerrors.ErrForbidden
 	}
 
-	accepted, err := s.acceptOrganizationInvitations(ctx, actorUserID, []types.OrganizationInvitation{*invitation})
+	accepted, err := s.acceptOrganizationInvitations(ctx, actor.ID, []types.OrganizationInvitation{*invitation})
 	if err != nil {
 		return nil, err
 	}
@@ -364,12 +364,12 @@ func (s *organizationInvitationService) AcceptOrganizationInvitation(ctx context
 	return &accepted[0], nil
 }
 
-func (s *organizationInvitationService) RejectOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	if actorUserID == "" || organizationID == "" || invitationID == "" {
+func (s *organizationInvitationService) RejectOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	if actor.ID == "" || organizationID == "" || invitationID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
-	user, err := s.userService.GetByID(ctx, actorUserID)
+	user, err := s.userService.GetByID(ctx, actor.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -404,9 +404,9 @@ func (s *organizationInvitationService) RejectOrganizationInvitation(ctx context
 	return updated, nil
 }
 
-func (s *organizationInvitationService) AcceptPendingOrganizationInvitationsForEmail(ctx context.Context, userID string, email string) ([]types.OrganizationInvitation, error) {
+func (s *organizationInvitationService) AcceptPendingOrganizationInvitationsForEmail(ctx context.Context, actor models.Actor, email string) ([]types.OrganizationInvitation, error) {
 	email = strings.ToLower(email)
-	if userID == "" || email == "" {
+	if actor.ID == "" || email == "" {
 		return nil, internalerrors.ErrUnprocessableEntity
 	}
 
@@ -415,7 +415,7 @@ func (s *organizationInvitationService) AcceptPendingOrganizationInvitationsForE
 	}
 
 	if s.pluginConfig.RequireEmailVerifiedOnInvitation {
-		if _, err := s.serviceUtils.ensureEmailVerifiedForInvitationAcceptance(ctx, s.userService, userID, true); err != nil {
+		if _, err := s.serviceUtils.ensureEmailVerifiedForInvitationAcceptance(ctx, s.userService, actor.ID, true); err != nil {
 			return nil, err
 		}
 	}
@@ -428,7 +428,7 @@ func (s *organizationInvitationService) AcceptPendingOrganizationInvitationsForE
 		return []types.OrganizationInvitation{}, nil
 	}
 
-	return s.acceptOrganizationInvitations(ctx, userID, pendingInvitations)
+	return s.acceptOrganizationInvitations(ctx, actor.ID, pendingInvitations)
 }
 
 func (s *organizationInvitationService) acceptOrganizationInvitations(ctx context.Context, userID string, invitations []types.OrganizationInvitation) ([]types.OrganizationInvitation, error) {

--- a/plugins/organizations/services/organization_invitation_service_test.go
+++ b/plugins/organizations/services/organization_invitation_service_test.go
@@ -113,7 +113,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 
 	tests := []struct {
 		name                 string
-		actorUserID          string
+		actor                models.Actor
 		organizationID       string
 		request              types.CreateOrganizationInvitationRequest
 		invitationExpiresIn  time.Duration
@@ -128,14 +128,14 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 	}{
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor:          models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:                "invalid role is rejected",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: 36 * time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "ghost"},
@@ -146,7 +146,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                 "higher role is forbidden",
-			actorUserID:          "user-1",
+			actor:                models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:       "org-1",
 			invitationExpiresIn:  36 * time.Hour,
 			request:              types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "manager"},
@@ -158,7 +158,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                 "access control forbidden is normalized",
-			actorUserID:          "user-1",
+			actor:                models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:       "org-1",
 			invitationExpiresIn:  36 * time.Hour,
 			request:              types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "manager"},
@@ -170,7 +170,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:           "forbidden for non owner",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks) {
@@ -180,7 +180,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "org member can create",
-			actorUserID:         "user-2",
+			actor:               models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -195,7 +195,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "success",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: 36 * time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -218,7 +218,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "members limit zero is treated as unlimited",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -235,7 +235,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "members limit allows create within quota",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -253,7 +253,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "members limit blocks when quota exceeded",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -268,7 +268,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "member quota still blocks before invitations quota",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -284,7 +284,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "invitations limit zero is treated as unlimited",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -301,7 +301,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "invitations limit allows create within quota",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -319,7 +319,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "invitations limit blocks when quota exceeded",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -334,7 +334,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "pending invitation still conflicts within invitations limit",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -350,7 +350,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "invitations limit repository count error is returned",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -365,7 +365,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "sends email and publishes event",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: 36 * time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member", RedirectURL: "https://app.example.com/welcome"},
@@ -405,7 +405,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "skips missing mailer",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: 36 * time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -422,7 +422,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "uses callback when configured",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: 36 * time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member", RedirectURL: "https://app.example.com/welcome"},
@@ -460,7 +460,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "callback error falls back to mailer",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: 36 * time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member"},
@@ -496,7 +496,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                "callback skips built-in mailer",
-			actorUserID:         "user-1",
+			actor:               models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID:      "org-1",
 			invitationExpiresIn: 36 * time.Hour,
 			request:             types.CreateOrganizationInvitationRequest{Email: "user@example.com", Role: "member", RedirectURL: "https://app.example.com/welcome"},
@@ -592,7 +592,7 @@ func TestOrganizationInvitationService_CreateOrganizationInvitation(t *testing.T
 				memberRepo,
 				serviceUtils,
 			)
-			inv, err := svc.CreateOrganizationInvitation(context.Background(), tt.actorUserID, tt.organizationID, tt.request)
+			inv, err := svc.CreateOrganizationInvitation(context.Background(), tt.actor, tt.organizationID, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.Nil(t, inv)
@@ -626,7 +626,7 @@ func TestOrganizationInvitationService_GetOrganizationInvitation(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		invitationID   string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationInvitationRepository, *orgtests.MockOrganizationMemberRepository)
@@ -636,7 +636,7 @@ func TestOrganizationInvitationService_GetOrganizationInvitation(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -648,7 +648,7 @@ func TestOrganizationInvitationService_GetOrganizationInvitation(t *testing.T) {
 		},
 		{
 			name:           "rejected invitation is returned",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -660,7 +660,7 @@ func TestOrganizationInvitationService_GetOrganizationInvitation(t *testing.T) {
 		},
 		{
 			name:           "org member can get",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -673,7 +673,7 @@ func TestOrganizationInvitationService_GetOrganizationInvitation(t *testing.T) {
 		},
 		{
 			name:           "pending invitation is returned as pending",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -702,7 +702,7 @@ func TestOrganizationInvitationService_GetOrganizationInvitation(t *testing.T) {
 			}
 
 			svc := newTestOrganizationInvitationService(&orgtests.MockOrganizationInvitationTxRunner{}, pluginConfig, &internaltests.MockUserService{}, orgtests.NewAccessControlServiceStub(), orgRepo, invRepo, memberRepo)
-			invitation, err := svc.GetOrganizationInvitation(context.Background(), tt.actorUserID, tt.organizationID, tt.invitationID)
+			invitation, err := svc.GetOrganizationInvitation(context.Background(), tt.actor, tt.organizationID, tt.invitationID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -726,7 +726,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationInvitationRepository, *orgtests.MockOrganizationMemberRepository)
 		expectErr      error
@@ -734,7 +734,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -744,7 +744,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 		},
 		{
 			name:           "rejected invitation is returned",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -754,7 +754,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 		},
 		{
 			name:           "org member can list",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "owner-1"}, nil).Once()
@@ -763,10 +763,10 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 			},
 			expectLen: 1,
 		},
-		{name: "unauthorized", actorUserID: "", organizationID: "org-1", expectErr: internalerrors.ErrUnauthorized},
+		{name: "unauthorized", actor: models.Actor{Type: models.ActorUser}, organizationID: "org-1", expectErr: internalerrors.ErrUnauthorized},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(nil, nil).Once()
@@ -775,7 +775,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 		},
 		{
 			name:           "organization lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return((*types.Organization)(nil), repoErr).Once()
@@ -784,7 +784,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "owner-1"}, nil).Once()
@@ -794,7 +794,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 		},
 		{
 			name:           "repo error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -821,7 +821,7 @@ func TestOrganizationInvitationService_GetAllOrganizationInvitations(t *testing.
 			}
 
 			svc := newTestOrganizationInvitationService(&orgtests.MockOrganizationInvitationTxRunner{}, pluginConfig, &internaltests.MockUserService{}, orgtests.NewAccessControlServiceStub(), orgRepo, invRepo, memberRepo)
-			invitations, err := svc.GetAllOrganizationInvitations(context.Background(), tt.actorUserID, tt.organizationID)
+			invitations, err := svc.GetAllOrganizationInvitations(context.Background(), tt.actor, tt.organizationID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -846,7 +846,7 @@ func TestOrganizationInvitationService_RevokeOrganizationInvitation(t *testing.T
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		invitationID   string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationInvitationRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationInvitationHooks)
@@ -855,7 +855,7 @@ func TestOrganizationInvitationService_RevokeOrganizationInvitation(t *testing.T
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks) {
@@ -869,7 +869,7 @@ func TestOrganizationInvitationService_RevokeOrganizationInvitation(t *testing.T
 		},
 		{
 			name:           "org member can revoke",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks) {
@@ -884,7 +884,7 @@ func TestOrganizationInvitationService_RevokeOrganizationInvitation(t *testing.T
 		},
 		{
 			name:           "expired pending conflict",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks) {
@@ -898,7 +898,7 @@ func TestOrganizationInvitationService_RevokeOrganizationInvitation(t *testing.T
 		},
 		{
 			name:           "update error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			invitationID:   "inv-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks) {
@@ -929,7 +929,7 @@ func TestOrganizationInvitationService_RevokeOrganizationInvitation(t *testing.T
 			}
 
 			svc := newTestOrganizationInvitationService(&orgtests.MockOrganizationInvitationTxRunner{}, pluginConfig, &internaltests.MockUserService{}, orgtests.NewAccessControlServiceStub(), orgRepo, invRepo, memberRepo)
-			invitation, err := svc.RevokeOrganizationInvitation(context.Background(), tt.actorUserID, tt.organizationID, tt.invitationID)
+			invitation, err := svc.RevokeOrganizationInvitation(context.Background(), tt.actor, tt.organizationID, tt.invitationID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -953,7 +953,7 @@ func TestOrganizationInvitationService_AcceptPendingOrganizationInvitationsForEm
 
 	tests := []struct {
 		name                     string
-		userID                   string
+		actor                    models.Actor
 		email                    string
 		requireEmailVerification bool
 		setup                    func(*internaltests.MockUserService, *orgtests.MockOrganizationRepository, *orgtests.MockOrganizationInvitationRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationInvitationHooks, *orgtests.MockOrganizationMemberHooks)
@@ -962,14 +962,14 @@ func TestOrganizationInvitationService_AcceptPendingOrganizationInvitationsForEm
 	}{
 		{
 			name:      "bad request invalid email",
-			userID:    "user-2",
+			actor:     models.Actor{ID: "user-2", Type: models.ActorUser},
 			email:     "not-an-email",
 			expectErr: internalerrors.ErrBadRequest,
 		},
 		{
-			name:   "success",
-			userID: "user-2",
-			email:  "USER@EXAMPLE.COM",
+			name:  "success",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
+			email: "USER@EXAMPLE.COM",
 			setup: func(userSvc *internaltests.MockUserService, orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
 				invRepo.On("GetAllPendingByEmail", mock.Anything, "user@example.com").Return([]types.OrganizationInvitation{{ID: "inv-1", OrganizationID: "org-1", Email: "user@example.com", Role: "member", Status: types.OrganizationInvitationStatusPending, ExpiresAt: time.Now().UTC().Add(time.Hour)}}, nil).Once()
 				memberRepo.On("GetByOrganizationIDAndUserID", mock.Anything, "org-1", "user-2").Return(nil, nil).Once()
@@ -984,7 +984,7 @@ func TestOrganizationInvitationService_AcceptPendingOrganizationInvitationsForEm
 		},
 		{
 			name:                     "forbidden when email verification is required and user is unverified",
-			userID:                   "user-2",
+			actor:                    models.Actor{ID: "user-2", Type: models.ActorUser},
 			email:                    "USER@EXAMPLE.COM",
 			requireEmailVerification: true,
 			setup: func(userSvc *internaltests.MockUserService, orgRepo *orgtests.MockOrganizationRepository, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1015,7 +1015,7 @@ func TestOrganizationInvitationService_AcceptPendingOrganizationInvitationsForEm
 
 			txRunner := &orgtests.MockOrganizationInvitationTxRunner{}
 			svc := newTestOrganizationInvitationService(txRunner, pluginConfig, userSvc, orgtests.NewAccessControlServiceStub(), orgRepo, invRepo, memberRepo)
-			accepted, err := svc.AcceptPendingOrganizationInvitationsForEmail(context.Background(), tt.userID, tt.email)
+			accepted, err := svc.AcceptPendingOrganizationInvitationsForEmail(context.Background(), tt.actor, tt.email)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tt.expectErr.Error())
@@ -1035,7 +1035,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 
 	tests := []struct {
 		name                     string
-		actorUserID              string
+		actor                    models.Actor
 		organization             string
 		invitationID             string
 		requireEmailVerification bool
@@ -1046,14 +1046,14 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 	}{
 		{
 			name:         "unauthorized",
-			actorUserID:  "",
+			actor:        models.Actor{Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			expectErr:    internalerrors.ErrUnauthorized,
 		},
 		{
 			name:         "success",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1069,7 +1069,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "forbidden when emails differ",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1080,7 +1080,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "user lookup error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1090,7 +1090,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "user not found",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1100,7 +1100,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "user missing email",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1110,7 +1110,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "invitation lookup error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1121,7 +1121,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "invitation not found",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1132,7 +1132,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "invitation from other organization",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1143,7 +1143,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "expired pending conflict",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1157,7 +1157,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "member lookup error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1169,7 +1169,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "member create error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1184,7 +1184,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "update error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationInvitationHooks, memberHooks *orgtests.MockOrganizationMemberHooks) {
@@ -1202,7 +1202,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "members quota exceeded",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			membersLimit: &limit,
@@ -1216,7 +1216,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "existing member is still accepted at capacity",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			membersLimit: &limit,
@@ -1232,7 +1232,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 		},
 		{
 			name:                     "forbidden when email verification is required and user is unverified",
-			actorUserID:              "user-2",
+			actor:                    models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization:             "org-1",
 			invitationID:             "inv-1",
 			requireEmailVerification: true,
@@ -1264,7 +1264,7 @@ func TestOrganizationInvitationService_AcceptOrganizationInvitation(t *testing.T
 			}
 
 			svc := newTestOrganizationInvitationService(&orgtests.MockOrganizationInvitationTxRunner{}, pluginConfig, userSvc, orgtests.NewAccessControlServiceStub(), orgRepo, invRepo, memberRepo)
-			invitation, err := svc.AcceptOrganizationInvitation(context.Background(), tt.actorUserID, tt.organization, tt.invitationID)
+			invitation, err := svc.AcceptOrganizationInvitation(context.Background(), tt.actor, tt.organization, tt.invitationID)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr)
 				return
@@ -1283,7 +1283,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 
 	tests := []struct {
 		name         string
-		actorUserID  string
+		actor        models.Actor
 		organization string
 		invitationID string
 		setup        func(*internaltests.MockUserService, *orgtests.MockOrganizationInvitationRepository)
@@ -1292,14 +1292,14 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 	}{
 		{
 			name:         "unauthorized",
-			actorUserID:  "",
+			actor:        models.Actor{Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			expectErr:    internalerrors.ErrUnauthorized,
 		},
 		{
 			name:         "success",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1313,7 +1313,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "user lookup error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1323,7 +1323,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "user not found",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1333,7 +1333,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "user missing email",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1343,7 +1343,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "invitation lookup error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1354,7 +1354,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "invitation not found",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1365,7 +1365,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "invitation from other organization",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1376,7 +1376,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "expired pending conflict",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1390,7 +1390,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "email mismatch forbidden",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1401,7 +1401,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 		},
 		{
 			name:         "update error",
-			actorUserID:  "user-2",
+			actor:        models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			invitationID: "inv-1",
 			setup: func(userSvc *internaltests.MockUserService, invRepo *orgtests.MockOrganizationInvitationRepository) {
@@ -1430,7 +1430,7 @@ func TestOrganizationInvitationService_RejectOrganizationInvitation(t *testing.T
 			}
 
 			svc := newTestOrganizationInvitationService(&orgtests.MockOrganizationInvitationTxRunner{}, pluginConfig, userSvc, orgtests.NewAccessControlServiceStub(), &orgtests.MockOrganizationRepository{}, invRepo, &orgtests.MockOrganizationMemberRepository{})
-			invitation, err := svc.RejectOrganizationInvitation(context.Background(), tt.actorUserID, tt.organization, tt.invitationID)
+			invitation, err := svc.RejectOrganizationInvitation(context.Background(), tt.actor, tt.organization, tt.invitationID)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr)
 				return

--- a/plugins/organizations/services/organization_member_service.go
+++ b/plugins/organizations/services/organization_member_service.go
@@ -8,6 +8,7 @@ import (
 
 	internalerrors "github.com/Authula/authula/internal/errors"
 	"github.com/Authula/authula/internal/util"
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/repositories"
 	"github.com/Authula/authula/plugins/organizations/types"
 	rootservices "github.com/Authula/authula/services"
@@ -31,8 +32,8 @@ func NewOrganizationMemberService(userService rootservices.UserService, accessCo
 	return &organizationMemberService{userService: userService, accessControlService: accessControlService, orgRepo: orgRepo, orgMemberRepo: orgMemberRepo, serviceUtils: serviceUtils, membersLimit: membersLimit, txRunner: txRunner}
 }
 
-func (s *organizationMemberService) AddMember(ctx context.Context, actorUserID string, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationMemberService) AddMember(ctx context.Context, actor models.Actor, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -60,7 +61,7 @@ func (s *organizationMemberService) AddMember(ctx context.Context, actorUserID s
 		return nil, internalerrors.ErrConflict
 	}
 
-	validatedRoleAssignment, err := s.accessControlService.ValidateRoleAssignment(ctx, role, &actorUserID)
+	validatedRoleAssignment, err := s.accessControlService.ValidateRoleAssignment(ctx, role, &actor.ID)
 	if err != nil {
 		if err.Error() == internalerrors.ErrForbidden.Error() {
 			return nil, internalerrors.ErrForbidden
@@ -103,16 +104,16 @@ func (s *organizationMemberService) AddMember(ctx context.Context, actorUserID s
 	return created, nil
 }
 
-func (s *organizationMemberService) GetAllMembers(ctx context.Context, actorUserID string, organizationID string, page int, limit int) ([]types.OrganizationMember, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationMemberService) GetAllMembers(ctx context.Context, actor models.Actor, organizationID string, page int, limit int) ([]types.OrganizationMember, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
 	return s.orgMemberRepo.GetAllByOrganizationID(ctx, organizationID, page, limit)
 }
 
-func (s *organizationMemberService) GetMember(ctx context.Context, actorUserID string, organizationID string, memberID string) (*types.OrganizationMember, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationMemberService) GetMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) (*types.OrganizationMember, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -131,8 +132,8 @@ func (s *organizationMemberService) GetMember(ctx context.Context, actorUserID s
 	return member, nil
 }
 
-func (s *organizationMemberService) UpdateMember(ctx context.Context, actorUserID string, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error) {
-	_, actorMember, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID)
+func (s *organizationMemberService) UpdateMember(ctx context.Context, actor models.Actor, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error) {
+	_, actorMember, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +151,7 @@ func (s *organizationMemberService) UpdateMember(ctx context.Context, actorUserI
 		return nil, internalerrors.ErrBadRequest
 	}
 
-	validatedRoleAssignment, err := s.accessControlService.ValidateRoleAssignment(ctx, role, &actorUserID)
+	validatedRoleAssignment, err := s.accessControlService.ValidateRoleAssignment(ctx, role, &actor.ID)
 	if err != nil {
 		if err.Error() == internalerrors.ErrForbidden.Error() {
 			return nil, internalerrors.ErrForbidden
@@ -178,8 +179,8 @@ func (s *organizationMemberService) UpdateMember(ctx context.Context, actorUserI
 	return updated, nil
 }
 
-func (s *organizationMemberService) RemoveMember(ctx context.Context, actorUserID string, organizationID string, memberID string) error {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationMemberService) RemoveMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) error {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return err
 	}
 

--- a/plugins/organizations/services/organization_member_service_test.go
+++ b/plugins/organizations/services/organization_member_service_test.go
@@ -33,7 +33,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		actorUserID          string
+		actor                models.Actor
 		organizationID       string
 		request              types.AddOrganizationMemberRequest
 		accessControlService rootservices.AccessControlService
@@ -42,15 +42,16 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		expectErr            error
 	}{
 		{
-			name:           "unauthorized",
-			actorUserID:    "",
+			name:  "unauthorized",
+			actor: models.Actor{Type: models.ActorUser},
+
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -60,7 +61,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "forbidden for non owner",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -71,7 +72,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "bad request empty user id",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -81,7 +82,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "bad request empty role",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: ""},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -91,7 +92,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "invalid role is rejected",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "ghost"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -103,7 +104,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "zero limit treated as unlimited",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			membersLimit:   &zeroLimit,
@@ -118,7 +119,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "success within limit",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			membersLimit:   &threeLimit,
@@ -134,7 +135,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "quota exceeded",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			membersLimit:   &twoLimit,
@@ -148,7 +149,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "count lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			membersLimit:   &twoLimit,
@@ -162,7 +163,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:                 "higher role is forbidden",
-			actorUserID:          "user-2",
+			actor:                models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID:       "org-1",
 			request:              types.AddOrganizationMemberRequest{UserID: "user-3", Role: "manager"},
 			accessControlService: orgtests.NewAccessControlServiceStubWithWeights(nil, map[string]int{"user-2": 10}),
@@ -176,7 +177,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:                 "access control forbidden is normalized",
-			actorUserID:          "user-2",
+			actor:                models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID:       "org-1",
 			request:              types.AddOrganizationMemberRequest{UserID: "user-3", Role: "manager"},
 			accessControlService: &orgtests.AccessControlServiceStub{Err: errors.New("forbidden")},
@@ -190,7 +191,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "user lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -201,7 +202,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "user not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -212,7 +213,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "existing member conflict",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -224,7 +225,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "lookup existing member error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -236,7 +237,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "create error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -251,7 +252,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.AddOrganizationMemberRequest{UserID: "user-2", Role: "member"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, userSvc *internaltests.MockUserService, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -283,7 +284,7 @@ func TestOrganizationMemberService_AddMember(t *testing.T) {
 			}
 
 			svc := newTestOrganizationMemberService(userSvc, accessControlService, orgRepo, memberRepo, tt.membersLimit)
-			member, err := svc.AddMember(context.Background(), tt.actorUserID, tt.organizationID, tt.request)
+			member, err := svc.AddMember(context.Background(), tt.actor, tt.organizationID, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				if strings.Contains(tt.name, "invalid role") {
@@ -316,7 +317,7 @@ func TestOrganizationMemberService_GetAllMembers(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository)
 		expectErr      error
@@ -324,13 +325,13 @@ func TestOrganizationMemberService_GetAllMembers(t *testing.T) {
 	}{
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor:          models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(nil, nil).Once()
@@ -339,7 +340,7 @@ func TestOrganizationMemberService_GetAllMembers(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "owner-1"}, nil).Once()
@@ -349,7 +350,7 @@ func TestOrganizationMemberService_GetAllMembers(t *testing.T) {
 		},
 		{
 			name:           "repository error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -359,7 +360,7 @@ func TestOrganizationMemberService_GetAllMembers(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -381,7 +382,7 @@ func TestOrganizationMemberService_GetAllMembers(t *testing.T) {
 			}
 
 			svc := newTestOrganizationMemberService(userService, orgtests.NewAccessControlServiceStub(), orgRepo, memberRepo, nil)
-			members, err := svc.GetAllMembers(context.Background(), tt.actorUserID, tt.organizationID, 1, 10)
+			members, err := svc.GetAllMembers(context.Background(), tt.actor, tt.organizationID, 1, 10)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -408,7 +409,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		memberID       string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository)
@@ -417,14 +418,14 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 	}{
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor:          models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:           "member id empty",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -434,7 +435,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 		},
 		{
 			name:           "member id whitespace",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "missing",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -445,7 +446,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -455,7 +456,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -466,7 +467,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 		},
 		{
 			name:           "repository error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -477,7 +478,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 		},
 		{
 			name:           "not found when member is missing",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -488,7 +489,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 		},
 		{
 			name:           "not found when member belongs to another organization",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -499,7 +500,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -522,7 +523,7 @@ func TestOrganizationMemberService_GetMember(t *testing.T) {
 			}
 
 			svc := newTestOrganizationMemberService(userService, orgtests.NewAccessControlServiceStub(), orgRepo, memberRepo, nil)
-			member, err := svc.GetMember(context.Background(), tt.actorUserID, tt.organizationID, tt.memberID)
+			member, err := svc.GetMember(context.Background(), tt.actor, tt.organizationID, tt.memberID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -551,7 +552,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		actorUserID          string
+		actor                models.Actor
 		organizationID       string
 		memberID             string
 		request              types.UpdateOrganizationMemberRequest
@@ -562,7 +563,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 	}{
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor:          models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -570,7 +571,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -581,7 +582,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -593,7 +594,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "repository error fetching member",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -605,7 +606,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "not found when member is missing",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -617,7 +618,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "not found when member belongs to another organization",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -629,7 +630,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "bad request empty role",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: ""},
@@ -641,7 +642,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "invalid role is rejected",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "ghost"},
@@ -653,7 +654,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:                 "higher role is forbidden",
-			actorUserID:          "user-2",
+			actor:                models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID:       "org-1",
 			memberID:             "mem-1",
 			request:              types.UpdateOrganizationMemberRequest{Role: "manager"},
@@ -667,7 +668,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:                 "access control forbidden is normalized",
-			actorUserID:          "user-2",
+			actor:                models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID:       "org-1",
 			memberID:             "mem-1",
 			request:              types.UpdateOrganizationMemberRequest{Role: "manager"},
@@ -681,7 +682,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "update error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -696,7 +697,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			request:        types.UpdateOrganizationMemberRequest{Role: "admin"},
@@ -729,7 +730,7 @@ func TestOrganizationMemberService_UpdateMember(t *testing.T) {
 			}
 
 			svc := newTestOrganizationMemberService(userService, accessControlService, orgRepo, memberRepo, nil)
-			member, err := svc.UpdateMember(context.Background(), tt.actorUserID, tt.organizationID, tt.memberID, tt.request)
+			member, err := svc.UpdateMember(context.Background(), tt.actor, tt.organizationID, tt.memberID, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				if strings.Contains(tt.name, "invalid role") {
@@ -762,7 +763,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		memberID       string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationMemberHooks)
@@ -770,14 +771,14 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 	}{
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor:          models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -787,7 +788,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -798,7 +799,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 		},
 		{
 			name:           "repository error fetching member",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -809,7 +810,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 		},
 		{
 			name:           "not found when member is missing",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -820,7 +821,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 		},
 		{
 			name:           "not found when member belongs to another organization",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -831,7 +832,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 		},
 		{
 			name:           "delete error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -843,7 +844,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			memberID:       "mem-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationMemberHooks) {
@@ -867,7 +868,7 @@ func TestOrganizationMemberService_RemoveMember(t *testing.T) {
 			}
 
 			svc := newTestOrganizationMemberService(userService, orgtests.NewAccessControlServiceStub(), orgRepo, memberRepo, nil)
-			err := svc.RemoveMember(context.Background(), tt.actorUserID, tt.organizationID, tt.memberID)
+			err := svc.RemoveMember(context.Background(), tt.actor, tt.organizationID, tt.memberID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)

--- a/plugins/organizations/services/organization_service.go
+++ b/plugins/organizations/services/organization_service.go
@@ -10,6 +10,7 @@ import (
 
 	internalerrors "github.com/Authula/authula/internal/errors"
 	"github.com/Authula/authula/internal/util"
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/constants"
 	"github.com/Authula/authula/plugins/organizations/repositories"
 	"github.com/Authula/authula/plugins/organizations/types"
@@ -33,8 +34,8 @@ func NewOrganizationService(orgRepo repositories.OrganizationRepository, orgMemb
 	return &organizationService{orgRepo: orgRepo, orgMemberRepo: orgMemberRepo, serviceUtils: serviceUtils, accessControlService: accessControlService, organizationsLimit: organizationsLimit, txRunner: txRunner}
 }
 
-func (s *organizationService) CreateOrganization(ctx context.Context, actorUserID string, request types.CreateOrganizationRequest) (*types.Organization, error) {
-	if actorUserID == "" {
+func (s *organizationService) CreateOrganization(ctx context.Context, actor models.Actor, request types.CreateOrganizationRequest) (*types.Organization, error) {
+	if actor.ID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
@@ -68,7 +69,7 @@ func (s *organizationService) CreateOrganization(ctx context.Context, actorUserI
 
 	organization := &types.Organization{
 		ID:       util.GenerateUUID(),
-		OwnerID:  actorUserID,
+		OwnerID:  actor.ID,
 		Name:     name,
 		Slug:     slug,
 		Logo:     request.Logo,
@@ -80,7 +81,7 @@ func (s *organizationService) CreateOrganization(ctx context.Context, actorUserI
 
 	var created *types.Organization
 	createFn := func(ctx context.Context, orgRepo repositories.OrganizationRepository, memberRepo repositories.OrganizationMemberRepository) error {
-		if err := s.ensureOrganizationLimit(ctx, actorUserID, orgRepo, memberRepo); err != nil {
+		if err := s.ensureOrganizationLimit(ctx, actor, orgRepo, memberRepo); err != nil {
 			return err
 		}
 
@@ -92,7 +93,7 @@ func (s *organizationService) CreateOrganization(ctx context.Context, actorUserI
 		member := &types.OrganizationMember{
 			ID:             util.GenerateUUID(),
 			OrganizationID: createdOrganization.ID,
-			UserID:         actorUserID,
+			UserID:         actor.ID,
 			Role:           role,
 		}
 
@@ -115,7 +116,7 @@ func (s *organizationService) CreateOrganization(ctx context.Context, actorUserI
 	return created, nil
 }
 
-func (s *organizationService) ensureOrganizationLimit(ctx context.Context, actorUserID string, orgRepo repositories.OrganizationRepository, memberRepo repositories.OrganizationMemberRepository) error {
+func (s *organizationService) ensureOrganizationLimit(ctx context.Context, actor models.Actor, orgRepo repositories.OrganizationRepository, memberRepo repositories.OrganizationMemberRepository) error {
 	if s.organizationsLimit == nil || *s.organizationsLimit <= 0 {
 		return nil
 	}
@@ -130,11 +131,11 @@ func (s *organizationService) ensureOrganizationLimit(ctx context.Context, actor
 	wg := sync.WaitGroup{}
 
 	wg.Go(func() {
-		ownedOrganizations, ownedOrganizationsErr = orgRepo.GetAllByOwnerID(ctx, actorUserID)
+		ownedOrganizations, ownedOrganizationsErr = orgRepo.GetAllByOwnerID(ctx, actor.ID)
 	})
 
 	wg.Go(func() {
-		memberRecords, memberRecordsErr = memberRepo.GetAllByUserID(ctx, actorUserID)
+		memberRecords, memberRecordsErr = memberRepo.GetAllByUserID(ctx, actor.ID)
 	})
 
 	wg.Wait()
@@ -167,17 +168,17 @@ func (s *organizationService) ensureOrganizationLimit(ctx context.Context, actor
 	return nil
 }
 
-func (s *organizationService) GetAllOrganizations(ctx context.Context, actorUserID string) ([]types.Organization, error) {
-	if actorUserID == "" {
+func (s *organizationService) GetAllOrganizations(ctx context.Context, actor models.Actor) ([]types.Organization, error) {
+	if actor.ID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
-	ownedOrganizations, err := s.orgRepo.GetAllByOwnerID(ctx, actorUserID)
+	ownedOrganizations, err := s.orgRepo.GetAllByOwnerID(ctx, actor.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	memberRecords, err := s.orgMemberRepo.GetAllByUserID(ctx, actorUserID)
+	memberRecords, err := s.orgMemberRepo.GetAllByUserID(ctx, actor.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -220,8 +221,8 @@ func (s *organizationService) GetAllOrganizations(ctx context.Context, actorUser
 	return organizations, nil
 }
 
-func (s *organizationService) GetOrganizationByID(ctx context.Context, actorUserID string, organizationID string) (*types.Organization, error) {
-	organization, err := s.authorizeMember(ctx, actorUserID, organizationID)
+func (s *organizationService) GetOrganizationByID(ctx context.Context, actor models.Actor, organizationID string) (*types.Organization, error) {
+	organization, err := s.authorizeMember(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -229,8 +230,8 @@ func (s *organizationService) GetOrganizationByID(ctx context.Context, actorUser
 	return organization, nil
 }
 
-func (s *organizationService) UpdateOrganization(ctx context.Context, actorUserID string, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error) {
-	organization, err := s.authorizeMember(ctx, actorUserID, organizationID)
+func (s *organizationService) UpdateOrganization(ctx context.Context, actor models.Actor, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error) {
+	organization, err := s.authorizeMember(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -273,8 +274,8 @@ func (s *organizationService) UpdateOrganization(ctx context.Context, actorUserI
 	return updated, nil
 }
 
-func (s *organizationService) DeleteOrganization(ctx context.Context, actorUserID string, organizationID string) error {
-	_, err := s.serviceUtils.authorizeOwner(ctx, actorUserID, organizationID)
+func (s *organizationService) DeleteOrganization(ctx context.Context, actor models.Actor, organizationID string) error {
+	_, err := s.serviceUtils.authorizeOwner(ctx, actor, organizationID)
 	if err != nil {
 		return err
 	}
@@ -286,8 +287,8 @@ func (s *organizationService) DeleteOrganization(ctx context.Context, actorUserI
 	return nil
 }
 
-func (s *organizationService) authorizeMember(ctx context.Context, actorUserID string, organizationID string) (*types.Organization, error) {
-	organization, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID)
+func (s *organizationService) authorizeMember(ctx context.Context, actor models.Actor, organizationID string) (*types.Organization, error) {
+	organization, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/organizations/services/organization_service_test.go
+++ b/plugins/organizations/services/organization_service_test.go
@@ -9,6 +9,7 @@ import (
 
 	internalerrors "github.com/Authula/authula/internal/errors"
 	internaltests "github.com/Authula/authula/internal/tests"
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/constants"
 	orgtests "github.com/Authula/authula/plugins/organizations/tests"
 	"github.com/Authula/authula/plugins/organizations/types"
@@ -50,7 +51,7 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		actorUserID       string
+		actor             models.Actor
 		organizationLimit *int
 		request           types.CreateOrganizationRequest
 		setup             func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationHooks, *ServiceUtils)
@@ -59,32 +60,32 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 		expectReturned    string
 	}{
 		{
-			name:        "unauthorized",
-			actorUserID: "",
-			request:     types.CreateOrganizationRequest{Name: "Acme", Role: "member"},
-			expectErr:   internalerrors.ErrUnauthorized,
+			name:      "unauthorized",
+			actor:     models.Actor{Type: models.ActorUser},
+			request:   types.CreateOrganizationRequest{Name: "Acme", Role: "member"},
+			expectErr: internalerrors.ErrUnauthorized,
 		},
 		{
-			name:        "missing role",
-			actorUserID: "user-1",
-			request:     types.CreateOrganizationRequest{Name: "Acme"},
-			expectErr:   internalerrors.ErrUnprocessableEntity,
+			name:      "missing role",
+			actor:     models.Actor{ID: "user-1", Type: models.ActorUser},
+			request:   types.CreateOrganizationRequest{Name: "Acme"},
+			expectErr: internalerrors.ErrUnprocessableEntity,
 		},
 		{
-			name:        "bad request",
-			actorUserID: "user-1",
-			request:     types.CreateOrganizationRequest{Name: "", Role: "member"},
-			expectErr:   internalerrors.ErrUnprocessableEntity,
+			name:      "bad request",
+			actor:     models.Actor{ID: "user-1", Type: models.ActorUser},
+			request:   types.CreateOrganizationRequest{Name: "", Role: "member"},
+			expectErr: internalerrors.ErrUnprocessableEntity,
 		},
 		{
-			name:        "invalid role",
-			actorUserID: "user-1",
-			request:     types.CreateOrganizationRequest{Name: "Acme", Role: "ghost"},
-			expectErr:   internalerrors.ErrUnprocessableEntity,
+			name:      "invalid role",
+			actor:     models.Actor{ID: "user-1", Type: models.ActorUser},
+			request:   types.CreateOrganizationRequest{Name: "Acme", Role: "ghost"},
+			expectErr: internalerrors.ErrUnprocessableEntity,
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			request:        types.CreateOrganizationRequest{Name: "Acme Inc", Role: "member", Metadata: map[string]any{"tier": "pro"}},
 			setup:          successSetup,
 			expectCalled:   true,
@@ -92,7 +93,7 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 		},
 		{
 			name:              "zero limit treated as unlimited",
-			actorUserID:       "user-1",
+			actor:             models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationLimit: &zeroLimit,
 			request:           types.CreateOrganizationRequest{Name: "Acme Inc", Role: "member", Metadata: map[string]any{"tier": "pro"}},
 			setup:             successSetup,
@@ -101,7 +102,7 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 		},
 		{
 			name:              "success within limit",
-			actorUserID:       "user-1",
+			actor:             models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationLimit: &threeLimit,
 			request:           types.CreateOrganizationRequest{Name: "Acme Labs", Role: "member"},
 			setup:             limitSuccessSetup,
@@ -110,7 +111,7 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 		},
 		{
 			name:              "quota exceeded across owned and member organizations",
-			actorUserID:       "user-1",
+			actor:             models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationLimit: &twoLimit,
 			request:           types.CreateOrganizationRequest{Name: "Acme Platform", Role: "member"},
 			setup:             quotaExceededSetup,
@@ -132,7 +133,7 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 			}
 
 			svc := NewOrganizationService(repo, memberRepo, serviceUtils, accessControlService, tt.organizationLimit, txRunner)
-			org, err := svc.CreateOrganization(context.Background(), tt.actorUserID, tt.request)
+			org, err := svc.CreateOrganization(context.Background(), tt.actor, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -160,20 +161,20 @@ func TestOrganizationService_GetAllOrganizations(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		actorUserID string
-		setup       func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository)
-		expectErr   error
-		expectLen   int
+		name      string
+		actor     models.Actor
+		setup     func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository)
+		expectErr error
+		expectLen int
 	}{
 		{
-			name:        "unauthorized",
-			actorUserID: "",
-			expectErr:   internalerrors.ErrUnauthorized,
+			name:      "unauthorized",
+			actor:     models.Actor{Type: models.ActorUser},
+			expectErr: internalerrors.ErrUnauthorized,
 		},
 		{
-			name:        "success",
-			actorUserID: "user-1",
+			name:  "success",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			setup: func(repo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				repo.On("GetAllByOwnerID", mock.Anything, "user-1").Return([]types.Organization{{ID: "org-1", OwnerID: "user-1", Name: "Acme"}}, nil).Once()
 				memberRepo.On("GetAllByUserID", mock.Anything, "user-1").Return([]types.OrganizationMember{{ID: "mem-1", OrganizationID: "org-2", UserID: "user-1", Role: "member"}}, nil).Once()
@@ -195,7 +196,7 @@ func TestOrganizationService_GetAllOrganizations(t *testing.T) {
 
 			serviceUtils := &ServiceUtils{orgRepo: repo, orgMemberRepo: memberRepo}
 			svc := NewOrganizationService(repo, memberRepo, serviceUtils, nil, nil, nil)
-			organizations, err := svc.GetAllOrganizations(context.Background(), tt.actorUserID)
+			organizations, err := svc.GetAllOrganizations(context.Background(), tt.actor)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -214,14 +215,14 @@ func TestOrganizationService_GetOrganizationByID(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository)
 		expectErr      error
 	}{
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(repo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				repo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "owner-1"}, nil).Once()
@@ -231,7 +232,7 @@ func TestOrganizationService_GetOrganizationByID(t *testing.T) {
 		},
 		{
 			name:           "success for member",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(repo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				repo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "owner-1"}, nil).Once()
@@ -240,7 +241,7 @@ func TestOrganizationService_GetOrganizationByID(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(repo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				repo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -260,7 +261,7 @@ func TestOrganizationService_GetOrganizationByID(t *testing.T) {
 
 			serviceUtils := &ServiceUtils{orgRepo: repo, orgMemberRepo: memberRepo}
 			svc := NewOrganizationService(repo, memberRepo, serviceUtils, nil, nil, nil)
-			org, err := svc.GetOrganizationByID(context.Background(), tt.actorUserID, tt.organizationID)
+			org, err := svc.GetOrganizationByID(context.Background(), tt.actor, tt.organizationID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -277,7 +278,7 @@ func TestOrganizationService_UpdateOrganization(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		request        types.UpdateOrganizationRequest
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationHooks, *ServiceUtils)
@@ -285,21 +286,21 @@ func TestOrganizationService_UpdateOrganization(t *testing.T) {
 	}{
 		{
 			name:           "unauthorized if not user ID provided",
-			actorUserID:    "",
+			actor:          models.Actor{Type: models.ActorUser},
 			organizationID: "",
 			request:        types.UpdateOrganizationRequest{Name: new("Acme Platform")},
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:           "unauthorized if no organization ID provided",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "",
 			request:        types.UpdateOrganizationRequest{Name: new("Acme Platform")},
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.UpdateOrganizationRequest{Name: new("Acme Platform")},
 			setup: func(repo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationHooks, serviceUtils *ServiceUtils) {
@@ -310,7 +311,7 @@ func TestOrganizationService_UpdateOrganization(t *testing.T) {
 		},
 		{
 			name:           "success for member",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.UpdateOrganizationRequest{Name: new("Acme Platform")},
 			setup: func(repo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationHooks, serviceUtils *ServiceUtils) {
@@ -323,7 +324,7 @@ func TestOrganizationService_UpdateOrganization(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.UpdateOrganizationRequest{Name: new("Acme Platform")},
 			setup: func(repo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationHooks, serviceUtils *ServiceUtils) {
@@ -349,7 +350,7 @@ func TestOrganizationService_UpdateOrganization(t *testing.T) {
 			}
 
 			svc := NewOrganizationService(repo, memberRepo, serviceUtils, nil, nil, nil)
-			org, err := svc.UpdateOrganization(context.Background(), tt.actorUserID, tt.organizationID, tt.request)
+			org, err := svc.UpdateOrganization(context.Background(), tt.actor, tt.organizationID, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -366,14 +367,14 @@ func TestOrganizationService_DeleteOrganization(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationHooks, *ServiceUtils)
 		expectErr      error
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(repo *orgtests.MockOrganizationRepository, hooks *orgtests.MockOrganizationHooks, serviceUtils *ServiceUtils) {
 				repo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -394,7 +395,7 @@ func TestOrganizationService_DeleteOrganization(t *testing.T) {
 			}
 
 			svc := NewOrganizationService(repo, nil, serviceUtils, nil, nil, nil)
-			err := svc.DeleteOrganization(context.Background(), tt.actorUserID, tt.organizationID)
+			err := svc.DeleteOrganization(context.Background(), tt.actor, tt.organizationID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)

--- a/plugins/organizations/services/organization_team_member_service.go
+++ b/plugins/organizations/services/organization_team_member_service.go
@@ -5,6 +5,7 @@ import (
 
 	internalerrors "github.com/Authula/authula/internal/errors"
 	"github.com/Authula/authula/internal/util"
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/repositories"
 	"github.com/Authula/authula/plugins/organizations/types"
 )
@@ -27,13 +28,13 @@ func NewOrganizationTeamMemberService(
 	return &organizationTeamMemberService{orgRepo: orgRepo, orgMemberRepo: orgMemberRepo, orgTeamRepo: teamRepo, orgTeamMemberRepo: orgTeamMemberRepo, serviceUtils: serviceUtils}
 }
 
-func (s *organizationTeamMemberService) AddTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error) {
+func (s *organizationTeamMemberService) AddTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error) {
 	orgMemberID := request.MemberID
 	if orgMemberID == "" {
 		return nil, internalerrors.ErrUnprocessableEntity
 	}
 
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -73,8 +74,8 @@ func (s *organizationTeamMemberService) AddTeamMember(ctx context.Context, actor
 	return created, nil
 }
 
-func (s *organizationTeamMemberService) GetAllTeamMembers(ctx context.Context, actorUserID string, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationTeamMemberService) GetAllTeamMembers(ctx context.Context, actor models.Actor, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -89,8 +90,8 @@ func (s *organizationTeamMemberService) GetAllTeamMembers(ctx context.Context, a
 	return s.orgTeamMemberRepo.GetAllByTeamID(ctx, teamID, page, limit)
 }
 
-func (s *organizationTeamMemberService) GetTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationTeamMemberService) GetTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -121,8 +122,8 @@ func (s *organizationTeamMemberService) GetTeamMember(ctx context.Context, actor
 	return teamMember, nil
 }
 
-func (s *organizationTeamMemberService) RemoveTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) error {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationTeamMemberService) RemoveTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) error {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return err
 	}
 

--- a/plugins/organizations/services/organization_team_member_service_test.go
+++ b/plugins/organizations/services/organization_team_member_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	internalerrors "github.com/Authula/authula/internal/errors"
+	"github.com/Authula/authula/models"
 	orgtests "github.com/Authula/authula/plugins/organizations/tests"
 	"github.com/Authula/authula/plugins/organizations/types"
 )
@@ -31,7 +32,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor            models.Actor
 		organizationID string
 		teamID         string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationTeamMemberRepository)
@@ -41,7 +42,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -54,7 +55,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 		},
 		{
 			name:           "org member can list",
-			actorUserID:    "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -68,14 +69,14 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 		},
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor: models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			expectErr:      internalerrors.ErrUnauthorized,
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -86,7 +87,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -98,7 +99,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 		},
 		{
 			name:           "team lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -110,7 +111,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 		},
 		{
 			name:           "team not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -122,7 +123,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 		},
 		{
 			name:           "team from another organization",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -134,7 +135,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 		},
 		{
 			name:           "repo error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository) {
@@ -160,7 +161,7 @@ func TestOrganizationTeamService_GetAllTeamMembers(t *testing.T) {
 			}
 
 			svc := newTestOrganizationTeamMemberService(orgRepo, memberRepo, teamRepo, teamMemberRepo)
-			members, err := svc.GetAllTeamMembers(context.Background(), tt.actorUserID, tt.organizationID, tt.teamID, 1, 10)
+			members, err := svc.GetAllTeamMembers(context.Background(), tt.actor, tt.organizationID, tt.teamID, 1, 10)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -188,7 +189,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor            models.Actor
 		organizationID string
 		teamID         string
 		request        types.AddOrganizationTeamMemberRequest
@@ -198,7 +199,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -215,7 +216,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "org member can add",
-			actorUserID:    "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -233,7 +234,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor: models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -241,7 +242,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -253,7 +254,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "organization lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -265,7 +266,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -278,7 +279,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -291,7 +292,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -304,7 +305,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team from another organization",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -317,7 +318,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "member from another organization",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -331,7 +332,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "bad request empty member id",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: ""},
@@ -340,7 +341,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "member lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -354,7 +355,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "member not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -368,7 +369,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team member conflict",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -383,7 +384,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team member lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -398,7 +399,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 		},
 		{
 			name:           "create error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.AddOrganizationTeamMemberRequest{MemberID: "member-1"},
@@ -438,7 +439,7 @@ func TestOrganizationTeamService_AddTeamMember(t *testing.T) {
 			}
 
 			svc := NewOrganizationTeamMemberService(orgRepo, memberRepo, teamRepo, teamMemberRepo, serviceUtils)
-			teamMember, err := svc.AddTeamMember(context.Background(), tt.actorUserID, tt.organizationID, tt.teamID, tt.request)
+			teamMember, err := svc.AddTeamMember(context.Background(), tt.actor, tt.organizationID, tt.teamID, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -465,7 +466,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor            models.Actor
 		organizationID string
 		teamID         string
 		memberID       string
@@ -476,7 +477,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -491,7 +492,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "org member can get",
-			actorUserID:    "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -507,7 +508,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor: models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -515,7 +516,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -527,7 +528,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -540,7 +541,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -553,7 +554,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -566,7 +567,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team from another organization",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -579,7 +580,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "repo error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -594,7 +595,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -608,7 +609,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 		},
 		{
 			name:           "whitespace member id",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "",
@@ -636,7 +637,7 @@ func TestOrganizationTeamService_GetTeamMember(t *testing.T) {
 			}
 
 			svc := newTestOrganizationTeamMemberService(orgRepo, memberRepo, teamRepo, teamMemberRepo)
-			teamMember, err := svc.GetTeamMember(context.Background(), tt.actorUserID, tt.organizationID, tt.teamID, tt.memberID)
+			teamMember, err := svc.GetTeamMember(context.Background(), tt.actor, tt.organizationID, tt.teamID, tt.memberID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -665,7 +666,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor            models.Actor
 		organizationID string
 		teamID         string
 		memberID       string
@@ -675,7 +676,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -690,7 +691,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "org member can remove",
-			actorUserID:    "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -706,7 +707,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "unauthorized",
-			actorUserID:    "",
+			actor: models.Actor{Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -714,7 +715,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -726,7 +727,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -739,7 +740,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -752,7 +753,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -765,7 +766,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team from another organization",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -778,7 +779,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "team member lookup error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -793,7 +794,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "member not found",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -807,7 +808,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 		},
 		{
 			name:           "delete error",
-			actorUserID:    "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			memberID:       "member-1",
@@ -837,7 +838,7 @@ func TestOrganizationTeamService_RemoveTeamMember(t *testing.T) {
 			}
 
 			svc := newTestOrganizationTeamMemberService(orgRepo, memberRepo, teamRepo, teamMemberRepo)
-			err := svc.RemoveTeamMember(context.Background(), tt.actorUserID, tt.organizationID, tt.teamID, tt.memberID)
+			err := svc.RemoveTeamMember(context.Background(), tt.actor, tt.organizationID, tt.teamID, tt.memberID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)

--- a/plugins/organizations/services/organization_team_service.go
+++ b/plugins/organizations/services/organization_team_service.go
@@ -8,6 +8,7 @@ import (
 
 	internalerrors "github.com/Authula/authula/internal/errors"
 	"github.com/Authula/authula/internal/util"
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/repositories"
 	"github.com/Authula/authula/plugins/organizations/types"
 )
@@ -36,8 +37,8 @@ func NewOrganizationTeamService(
 	return &organizationTeamService{orgRepo: orgRepo, orgTeamRepo: orgTeamRepo, orgMemberRepo: orgMemberRepo, orgTeamMemberRepo: orgTeamMemberRepo, serviceUtils: serviceUtils, txRunner: txRunner}
 }
 
-func (s *organizationTeamService) CreateTeam(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
-	organization, actorMember, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID)
+func (s *organizationTeamService) CreateTeam(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
+	organization, actorMember, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func (s *organizationTeamService) CreateTeam(ctx context.Context, actorUserID st
 		}
 
 		if actorMember == nil {
-			actorMember, err = memberRepo.GetByOrganizationIDAndUserID(ctx, organization.ID, actorUserID)
+			actorMember, err = memberRepo.GetByOrganizationIDAndUserID(ctx, organization.ID, actor.ID)
 			if err != nil {
 				return err
 			}
@@ -122,16 +123,16 @@ func (s *organizationTeamService) CreateTeam(ctx context.Context, actorUserID st
 	return created, nil
 }
 
-func (s *organizationTeamService) GetAllTeams(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationTeam, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationTeamService) GetAllTeams(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationTeam, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
 	return s.orgTeamRepo.GetAllByOrganizationID(ctx, organizationID)
 }
 
-func (s *organizationTeamService) GetTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) (*types.OrganizationTeam, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationTeamService) GetTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) (*types.OrganizationTeam, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -146,8 +147,8 @@ func (s *organizationTeamService) GetTeam(ctx context.Context, actorUserID strin
 	return team, nil
 }
 
-func (s *organizationTeamService) UpdateTeam(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationTeamService) UpdateTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -197,8 +198,8 @@ func (s *organizationTeamService) UpdateTeam(ctx context.Context, actorUserID st
 	return updated, nil
 }
 
-func (s *organizationTeamService) DeleteTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) error {
-	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actorUserID, organizationID); err != nil {
+func (s *organizationTeamService) DeleteTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) error {
+	if _, _, err := s.serviceUtils.authorizeOrganizationAccess(ctx, actor, organizationID); err != nil {
 		return err
 	}
 

--- a/plugins/organizations/services/organization_team_service_test.go
+++ b/plugins/organizations/services/organization_team_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	internalerrors "github.com/Authula/authula/internal/errors"
+	"github.com/Authula/authula/models"
 	orgtests "github.com/Authula/authula/plugins/organizations/tests"
 	"github.com/Authula/authula/plugins/organizations/types"
 )
@@ -32,7 +33,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		actorUserID      string
+		actor            models.Actor
 		organizationID   string
 		request          types.CreateOrganizationTeamRequest
 		setup            func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationTeamMemberRepository, *orgtests.MockOrganizationTeamHooks, *ServiceUtils)
@@ -42,7 +43,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Acme Platform"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -66,7 +67,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "org member can create",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Acme Platform", Metadata: map[string]any{"tier": "core"}},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -92,7 +93,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 
 	tests = append(tests, []struct {
 		name             string
-		actorUserID      string
+		actor            models.Actor
 		organizationID   string
 		request          types.CreateOrganizationTeamRequest
 		setup            func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationTeamMemberRepository, *orgtests.MockOrganizationTeamHooks, *ServiceUtils)
@@ -100,10 +101,10 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		expectCalled     bool
 		expectTeamMember bool
 	}{
-		{name: "unauthorized", actorUserID: "", organizationID: "org-1", request: types.CreateOrganizationTeamRequest{Name: "Platform"}, expectErr: internalerrors.ErrUnauthorized},
+		{name: "unauthorized", actor: models.Actor{Type: models.ActorUser}, organizationID: "org-1", request: types.CreateOrganizationTeamRequest{Name: "Platform"}, expectErr: internalerrors.ErrUnauthorized},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Platform"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -113,7 +114,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "organization lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Platform"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -123,7 +124,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Platform"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -133,7 +134,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "bad request empty name",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: ""},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -143,7 +144,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "bad request empty slugify result",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "!!!"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -153,7 +154,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "slug lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Platform"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -164,7 +165,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "slug conflict",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Platform"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -175,7 +176,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 		},
 		{
 			name:           "create error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			request:        types.CreateOrganizationTeamRequest{Name: "Platform"},
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, teamMemberRepo *orgtests.MockOrganizationTeamMemberRepository, hooks *orgtests.MockOrganizationTeamHooks, serviceUtils *ServiceUtils) {
@@ -210,7 +211,7 @@ func TestOrganizationTeamService_CreateTeam(t *testing.T) {
 			}
 
 			svc := NewOrganizationTeamService(orgRepo, memberRepo, teamRepo, teamMemberRepo, serviceUtils, txRunner)
-			team, err := svc.CreateTeam(context.Background(), tt.actorUserID, tt.organizationID, tt.request)
+			team, err := svc.CreateTeam(context.Background(), tt.actor, tt.organizationID, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -237,7 +238,7 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository)
 		expectErr      error
@@ -245,7 +246,7 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -255,7 +256,7 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 		},
 		{
 			name:           "org member can list",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "owner-1"}, nil).Once()
@@ -268,16 +269,16 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 
 	tests = append(tests, []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository)
 		expectErr      error
 		expectLen      int
 	}{
-		{name: "unauthorized", actorUserID: "", organizationID: "org-1", expectErr: internalerrors.ErrUnauthorized},
+		{name: "unauthorized", actor: models.Actor{Type: models.ActorUser}, organizationID: "org-1", expectErr: internalerrors.ErrUnauthorized},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(nil, nil).Once()
@@ -286,7 +287,7 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 		},
 		{
 			name:           "organization lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return((*types.Organization)(nil), repoErr).Once()
@@ -295,7 +296,7 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "owner-1"}, nil).Once()
@@ -304,7 +305,7 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 		},
 		{
 			name:           "repo error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -326,7 +327,7 @@ func TestOrganizationTeamService_GetAllTeams(t *testing.T) {
 			}
 
 			svc := newTestOrganizationTeamService(orgRepo, memberRepo, teamRepo, &orgtests.MockOrganizationTeamMemberRepository{})
-			teams, err := svc.GetAllTeams(context.Background(), tt.actorUserID, tt.organizationID)
+			teams, err := svc.GetAllTeams(context.Background(), tt.actor, tt.organizationID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -343,7 +344,7 @@ func TestOrganizationTeamService_GetTeam(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		teamID         string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository)
@@ -352,7 +353,7 @@ func TestOrganizationTeamService_GetTeam(t *testing.T) {
 	}{
 		{
 			name:           "owner can get team",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -363,7 +364,7 @@ func TestOrganizationTeamService_GetTeam(t *testing.T) {
 		},
 		{
 			name:           "org member can get team",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -375,7 +376,7 @@ func TestOrganizationTeamService_GetTeam(t *testing.T) {
 		},
 		{
 			name:           "non member forbidden",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
@@ -399,7 +400,7 @@ func TestOrganizationTeamService_GetTeam(t *testing.T) {
 			}
 
 			svc := newTestOrganizationTeamService(orgRepo, memberRepo, teamRepo, teamMemberRepo)
-			team, err := svc.GetTeam(context.Background(), tt.actorUserID, tt.organizationID, tt.teamID)
+			team, err := svc.GetTeam(context.Background(), tt.actor, tt.organizationID, tt.teamID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -423,7 +424,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		teamID         string
 		request        types.UpdateOrganizationTeamRequest
@@ -432,7 +433,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 	}{
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform"},
@@ -443,7 +444,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform Revamp"},
@@ -458,7 +459,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "org member can update",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform Revamp"},
@@ -476,17 +477,17 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 
 	tests = append(tests, []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		teamID         string
 		request        types.UpdateOrganizationTeamRequest
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationTeamHooks)
 		expectErr      error
 	}{
-		{name: "unauthorized", actorUserID: "", organizationID: "org-1", teamID: "team-1", request: types.UpdateOrganizationTeamRequest{Name: "Platform"}, expectErr: internalerrors.ErrUnauthorized},
+		{name: "unauthorized", actor: models.Actor{Type: models.ActorUser}, organizationID: "org-1", teamID: "team-1", request: types.UpdateOrganizationTeamRequest{Name: "Platform"}, expectErr: internalerrors.ErrUnauthorized},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform"},
@@ -497,7 +498,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "organization lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform"},
@@ -508,7 +509,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform"},
@@ -519,7 +520,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "team lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform"},
@@ -531,7 +532,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "team not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform"},
@@ -543,7 +544,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "team from another organization",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform"},
@@ -555,7 +556,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "bad request empty name",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: ""},
@@ -567,7 +568,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "bad request empty slugify result",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "!!!", Slug: func() *string { value := ""; return &value }()},
@@ -579,7 +580,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "slug lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform", Slug: func() *string { value := "platform"; return &value }()},
@@ -592,7 +593,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "slug conflict",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform", Slug: func() *string { value := "platform"; return &value }()},
@@ -605,7 +606,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 		},
 		{
 			name:           "update error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			request:        types.UpdateOrganizationTeamRequest{Name: "Platform Revamp"},
@@ -635,7 +636,7 @@ func TestOrganizationTeamService_UpdateTeam(t *testing.T) {
 			}
 
 			svc := newTestOrganizationTeamService(orgRepo, memberRepo, teamRepo, teamMemberRepo)
-			team, err := svc.UpdateTeam(context.Background(), tt.actorUserID, tt.organizationID, tt.teamID, tt.request)
+			team, err := svc.UpdateTeam(context.Background(), tt.actor, tt.organizationID, tt.teamID, tt.request)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)
@@ -656,7 +657,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		teamID         string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationTeamHooks)
@@ -664,7 +665,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 	}{
 		{
 			name:           "success",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -675,7 +676,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 		},
 		{
 			name:           "org member can delete",
-			actorUserID:    "user-2",
+			actor:          models.Actor{ID: "user-2", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -689,16 +690,16 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 
 	tests = append(tests, []struct {
 		name           string
-		actorUserID    string
+		actor          models.Actor
 		organizationID string
 		teamID         string
 		setup          func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationTeamRepository, *orgtests.MockOrganizationMemberRepository, *orgtests.MockOrganizationTeamHooks)
 		expectErr      error
 	}{
-		{name: "unauthorized", actorUserID: "", organizationID: "org-1", teamID: "team-1", expectErr: internalerrors.ErrUnauthorized},
+		{name: "unauthorized", actor: models.Actor{Type: models.ActorUser}, organizationID: "org-1", teamID: "team-1", expectErr: internalerrors.ErrUnauthorized},
 		{
 			name:           "organization not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -708,7 +709,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 		},
 		{
 			name:           "organization lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -718,7 +719,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 		},
 		{
 			name:           "forbidden",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -729,7 +730,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 		},
 		{
 			name:           "team lookup error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -740,7 +741,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 		},
 		{
 			name:           "team not found",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -751,7 +752,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 		},
 		{
 			name:           "team from another organization",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -762,7 +763,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 		},
 		{
 			name:           "delete error",
-			actorUserID:    "user-1",
+			actor:          models.Actor{ID: "user-1", Type: models.ActorUser},
 			organizationID: "org-1",
 			teamID:         "team-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, teamRepo *orgtests.MockOrganizationTeamRepository, memberRepo *orgtests.MockOrganizationMemberRepository, hooks *orgtests.MockOrganizationTeamHooks) {
@@ -788,7 +789,7 @@ func TestOrganizationTeamService_DeleteTeam(t *testing.T) {
 			}
 
 			svc := newTestOrganizationTeamService(orgRepo, memberRepo, teamRepo, teamMemberRepo)
-			err := svc.DeleteTeam(context.Background(), tt.actorUserID, tt.organizationID, tt.teamID)
+			err := svc.DeleteTeam(context.Background(), tt.actor, tt.organizationID, tt.teamID)
 			if tt.expectErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.expectErr)

--- a/plugins/organizations/services/service_utils.go
+++ b/plugins/organizations/services/service_utils.go
@@ -29,8 +29,8 @@ func NewServiceUtils(orgRepo repositories.OrganizationRepository, orgMemberRepo 
 	}
 }
 
-func (s *ServiceUtils) authorizeOwner(ctx context.Context, actorUserID string, organizationID string) (*types.Organization, error) {
-	if actorUserID == "" || organizationID == "" {
+func (s *ServiceUtils) authorizeOwner(ctx context.Context, actor models.Actor, organizationID string) (*types.Organization, error) {
+	if actor.ID == "" || organizationID == "" {
 		return nil, internalerrors.ErrUnauthorized
 	}
 
@@ -41,15 +41,15 @@ func (s *ServiceUtils) authorizeOwner(ctx context.Context, actorUserID string, o
 	if organization == nil {
 		return nil, internalerrors.ErrNotFound
 	}
-	if organization.OwnerID != actorUserID {
+	if organization.OwnerID != actor.ID {
 		return nil, internalerrors.ErrForbidden
 	}
 
 	return organization, nil
 }
 
-func (s *ServiceUtils) authorizeOrganizationAccess(ctx context.Context, actorUserID string, organizationID string) (*types.Organization, *types.OrganizationMember, error) {
-	if actorUserID == "" || organizationID == "" {
+func (s *ServiceUtils) authorizeOrganizationAccess(ctx context.Context, actor models.Actor, organizationID string) (*types.Organization, *types.OrganizationMember, error) {
+	if actor.ID == "" || organizationID == "" {
 		return nil, nil, internalerrors.ErrUnauthorized
 	}
 
@@ -60,11 +60,11 @@ func (s *ServiceUtils) authorizeOrganizationAccess(ctx context.Context, actorUse
 	if organization == nil {
 		return nil, nil, internalerrors.ErrNotFound
 	}
-	if organization.OwnerID == actorUserID {
+	if organization.OwnerID == actor.ID {
 		return organization, nil, nil
 	}
 
-	member, err := s.orgMemberRepo.GetByOrganizationIDAndUserID(ctx, organizationID, actorUserID)
+	member, err := s.orgMemberRepo.GetByOrganizationIDAndUserID(ctx, organizationID, actor.ID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/plugins/organizations/services/service_utils_test.go
+++ b/plugins/organizations/services/service_utils_test.go
@@ -23,7 +23,7 @@ func TestServiceUtils_authorizeOwner(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		actorUserID  string
+		actor            models.Actor
 		organization string
 		setup        func(*orgtests.MockOrganizationRepository)
 		expectErr    error
@@ -31,7 +31,7 @@ func TestServiceUtils_authorizeOwner(t *testing.T) {
 	}{
 		{
 			name:         "success",
-			actorUserID:  "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -40,13 +40,13 @@ func TestServiceUtils_authorizeOwner(t *testing.T) {
 		},
 		{
 			name:         "unauthorized when inputs are missing",
-			actorUserID:  "",
+			actor: models.Actor{Type: models.ActorUser},
 			organization: "org-1",
 			expectErr:    internalerrors.ErrUnauthorized,
 		},
 		{
 			name:         "not found when organization is missing",
-			actorUserID:  "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return((*types.Organization)(nil), nil).Once()
@@ -55,7 +55,7 @@ func TestServiceUtils_authorizeOwner(t *testing.T) {
 		},
 		{
 			name:         "forbidden when actor is not owner",
-			actorUserID:  "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -64,7 +64,7 @@ func TestServiceUtils_authorizeOwner(t *testing.T) {
 		},
 		{
 			name:         "propagates repository error",
-			actorUserID:  "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return((*types.Organization)(nil), repoErr).Once()
@@ -82,7 +82,7 @@ func TestServiceUtils_authorizeOwner(t *testing.T) {
 				tt.setup(orgRepo)
 			}
 
-			org, err := (&ServiceUtils{orgRepo: orgRepo}).authorizeOwner(context.Background(), tt.actorUserID, tt.organization)
+			org, err := (&ServiceUtils{orgRepo: orgRepo}).authorizeOwner(context.Background(), tt.actor, tt.organization)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr)
 				require.Nil(t, org)
@@ -106,7 +106,7 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		actorUserID  string
+		actor            models.Actor
 		organization string
 		setup        func(*orgtests.MockOrganizationRepository, *orgtests.MockOrganizationMemberRepository)
 		expectErr    error
@@ -115,7 +115,7 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 	}{
 		{
 			name:         "owner access",
-			actorUserID:  "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -124,7 +124,7 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 		},
 		{
 			name:         "member access",
-			actorUserID:  "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -134,13 +134,13 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 		},
 		{
 			name:         "unauthorized when inputs are missing",
-			actorUserID:  "",
+			actor: models.Actor{Type: models.ActorUser},
 			organization: "org-1",
 			expectErr:    internalerrors.ErrUnauthorized,
 		},
 		{
 			name:         "not found when organization is missing",
-			actorUserID:  "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return((*types.Organization)(nil), nil).Once()
@@ -149,7 +149,7 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 		},
 		{
 			name:         "forbidden when member is missing",
-			actorUserID:  "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -159,7 +159,7 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 		},
 		{
 			name:         "propagates organization repository error",
-			actorUserID:  "user-1",
+			actor: models.Actor{ID: "user-1", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return((*types.Organization)(nil), orgErr).Once()
@@ -168,7 +168,7 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 		},
 		{
 			name:         "propagates member repository error",
-			actorUserID:  "user-2",
+			actor: models.Actor{ID: "user-2", Type: models.ActorUser},
 			organization: "org-1",
 			setup: func(orgRepo *orgtests.MockOrganizationRepository, memberRepo *orgtests.MockOrganizationMemberRepository) {
 				orgRepo.On("GetByID", mock.Anything, "org-1").Return(&types.Organization{ID: "org-1", OwnerID: "user-1"}, nil).Once()
@@ -188,7 +188,7 @@ func TestServiceUtils_authorizeOrganizationAccess(t *testing.T) {
 				tt.setup(orgRepo, memberRepo)
 			}
 
-			org, member, err := (&ServiceUtils{orgRepo: orgRepo, orgMemberRepo: memberRepo}).authorizeOrganizationAccess(context.Background(), tt.actorUserID, tt.organization)
+			org, member, err := (&ServiceUtils{orgRepo: orgRepo, orgMemberRepo: memberRepo}).authorizeOrganizationAccess(context.Background(), tt.actor, tt.organization)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr)
 				require.Nil(t, org)

--- a/plugins/organizations/tests/services.go
+++ b/plugins/organizations/tests/services.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/Authula/authula/models"
 	"github.com/Authula/authula/plugins/organizations/types"
 )
 
@@ -12,40 +13,40 @@ type MockOrganizationService struct {
 	mock.Mock
 }
 
-func (m *MockOrganizationService) CreateOrganization(ctx context.Context, actorUserID string, request types.CreateOrganizationRequest) (*types.Organization, error) {
-	args := m.Called(ctx, actorUserID, request)
+func (m *MockOrganizationService) CreateOrganization(ctx context.Context, actor models.Actor, request types.CreateOrganizationRequest) (*types.Organization, error) {
+	args := m.Called(ctx, actor, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.Organization), args.Error(1)
 }
 
-func (m *MockOrganizationService) GetAllOrganizations(ctx context.Context, actorUserID string) ([]types.Organization, error) {
-	args := m.Called(ctx, actorUserID)
+func (m *MockOrganizationService) GetAllOrganizations(ctx context.Context, actor models.Actor) ([]types.Organization, error) {
+	args := m.Called(ctx, actor)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]types.Organization), args.Error(1)
 }
 
-func (m *MockOrganizationService) GetOrganizationByID(ctx context.Context, actorUserID string, organizationID string) (*types.Organization, error) {
-	args := m.Called(ctx, actorUserID, organizationID)
+func (m *MockOrganizationService) GetOrganizationByID(ctx context.Context, actor models.Actor, organizationID string) (*types.Organization, error) {
+	args := m.Called(ctx, actor, organizationID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.Organization), args.Error(1)
 }
 
-func (m *MockOrganizationService) UpdateOrganization(ctx context.Context, actorUserID string, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error) {
-	args := m.Called(ctx, actorUserID, organizationID, request)
+func (m *MockOrganizationService) UpdateOrganization(ctx context.Context, actor models.Actor, organizationID string, request types.UpdateOrganizationRequest) (*types.Organization, error) {
+	args := m.Called(ctx, actor, organizationID, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.Organization), args.Error(1)
 }
 
-func (m *MockOrganizationService) DeleteOrganization(ctx context.Context, actorUserID string, organizationID string) error {
-	args := m.Called(ctx, actorUserID, organizationID)
+func (m *MockOrganizationService) DeleteOrganization(ctx context.Context, actor models.Actor, organizationID string) error {
+	args := m.Called(ctx, actor, organizationID)
 	return args.Error(0)
 }
 
@@ -53,48 +54,48 @@ type MockOrganizationInvitationService struct {
 	mock.Mock
 }
 
-func (m *MockOrganizationInvitationService) CreateOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error) {
-	args := m.Called(ctx, actorUserID, organizationID, request)
+func (m *MockOrganizationInvitationService) CreateOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationInvitationRequest) (*types.OrganizationInvitation, error) {
+	args := m.Called(ctx, actor, organizationID, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationInvitation), args.Error(1)
 }
 
-func (m *MockOrganizationInvitationService) GetOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	args := m.Called(ctx, actorUserID, organizationID, invitationID)
+func (m *MockOrganizationInvitationService) GetOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	args := m.Called(ctx, actor, organizationID, invitationID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationInvitation), args.Error(1)
 }
 
-func (m *MockOrganizationInvitationService) GetAllOrganizationInvitations(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationInvitation, error) {
-	args := m.Called(ctx, actorUserID, organizationID)
+func (m *MockOrganizationInvitationService) GetAllOrganizationInvitations(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationInvitation, error) {
+	args := m.Called(ctx, actor, organizationID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]types.OrganizationInvitation), args.Error(1)
 }
 
-func (m *MockOrganizationInvitationService) RevokeOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	args := m.Called(ctx, actorUserID, organizationID, invitationID)
+func (m *MockOrganizationInvitationService) RevokeOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	args := m.Called(ctx, actor, organizationID, invitationID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationInvitation), args.Error(1)
 }
 
-func (m *MockOrganizationInvitationService) AcceptOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	args := m.Called(ctx, actorUserID, organizationID, invitationID)
+func (m *MockOrganizationInvitationService) AcceptOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	args := m.Called(ctx, actor, organizationID, invitationID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationInvitation), args.Error(1)
 }
 
-func (m *MockOrganizationInvitationService) RejectOrganizationInvitation(ctx context.Context, actorUserID string, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
-	args := m.Called(ctx, actorUserID, organizationID, invitationID)
+func (m *MockOrganizationInvitationService) RejectOrganizationInvitation(ctx context.Context, actor models.Actor, organizationID string, invitationID string) (*types.OrganizationInvitation, error) {
+	args := m.Called(ctx, actor, organizationID, invitationID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -105,40 +106,40 @@ type MockOrganizationMemberService struct {
 	mock.Mock
 }
 
-func (m *MockOrganizationMemberService) AddMember(ctx context.Context, actorUserID string, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error) {
-	args := m.Called(ctx, actorUserID, organizationID, request)
+func (m *MockOrganizationMemberService) AddMember(ctx context.Context, actor models.Actor, organizationID string, request types.AddOrganizationMemberRequest) (*types.OrganizationMember, error) {
+	args := m.Called(ctx, actor, organizationID, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationMember), args.Error(1)
 }
 
-func (m *MockOrganizationMemberService) GetAllMembers(ctx context.Context, actorUserID string, organizationID string, page int, limit int) ([]types.OrganizationMember, error) {
-	args := m.Called(ctx, actorUserID, organizationID, page, limit)
+func (m *MockOrganizationMemberService) GetAllMembers(ctx context.Context, actor models.Actor, organizationID string, page int, limit int) ([]types.OrganizationMember, error) {
+	args := m.Called(ctx, actor, organizationID, page, limit)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]types.OrganizationMember), args.Error(1)
 }
 
-func (m *MockOrganizationMemberService) GetMember(ctx context.Context, actorUserID string, organizationID string, memberID string) (*types.OrganizationMember, error) {
-	args := m.Called(ctx, actorUserID, organizationID, memberID)
+func (m *MockOrganizationMemberService) GetMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) (*types.OrganizationMember, error) {
+	args := m.Called(ctx, actor, organizationID, memberID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationMember), args.Error(1)
 }
 
-func (m *MockOrganizationMemberService) UpdateMember(ctx context.Context, actorUserID string, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error) {
-	args := m.Called(ctx, actorUserID, organizationID, memberID, request)
+func (m *MockOrganizationMemberService) UpdateMember(ctx context.Context, actor models.Actor, organizationID string, memberID string, request types.UpdateOrganizationMemberRequest) (*types.OrganizationMember, error) {
+	args := m.Called(ctx, actor, organizationID, memberID, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationMember), args.Error(1)
 }
 
-func (m *MockOrganizationMemberService) RemoveMember(ctx context.Context, actorUserID string, organizationID string, memberID string) error {
-	args := m.Called(ctx, actorUserID, organizationID, memberID)
+func (m *MockOrganizationMemberService) RemoveMember(ctx context.Context, actor models.Actor, organizationID string, memberID string) error {
+	args := m.Called(ctx, actor, organizationID, memberID)
 	return args.Error(0)
 }
 
@@ -146,40 +147,40 @@ type MockOrganizationTeamService struct {
 	mock.Mock
 }
 
-func (m *MockOrganizationTeamService) CreateTeam(ctx context.Context, actorUserID string, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
-	args := m.Called(ctx, actorUserID, organizationID, request)
+func (m *MockOrganizationTeamService) CreateTeam(ctx context.Context, actor models.Actor, organizationID string, request types.CreateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
+	args := m.Called(ctx, actor, organizationID, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationTeam), args.Error(1)
 }
 
-func (m *MockOrganizationTeamService) GetAllTeams(ctx context.Context, actorUserID string, organizationID string) ([]types.OrganizationTeam, error) {
-	args := m.Called(ctx, actorUserID, organizationID)
+func (m *MockOrganizationTeamService) GetAllTeams(ctx context.Context, actor models.Actor, organizationID string) ([]types.OrganizationTeam, error) {
+	args := m.Called(ctx, actor, organizationID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]types.OrganizationTeam), args.Error(1)
 }
 
-func (m *MockOrganizationTeamService) GetTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) (*types.OrganizationTeam, error) {
-	args := m.Called(ctx, actorUserID, organizationID, teamID)
+func (m *MockOrganizationTeamService) GetTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) (*types.OrganizationTeam, error) {
+	args := m.Called(ctx, actor, organizationID, teamID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationTeam), args.Error(1)
 }
 
-func (m *MockOrganizationTeamService) UpdateTeam(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
-	args := m.Called(ctx, actorUserID, organizationID, teamID, request)
+func (m *MockOrganizationTeamService) UpdateTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.UpdateOrganizationTeamRequest) (*types.OrganizationTeam, error) {
+	args := m.Called(ctx, actor, organizationID, teamID, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationTeam), args.Error(1)
 }
 
-func (m *MockOrganizationTeamService) DeleteTeam(ctx context.Context, actorUserID string, organizationID string, teamID string) error {
-	args := m.Called(ctx, actorUserID, organizationID, teamID)
+func (m *MockOrganizationTeamService) DeleteTeam(ctx context.Context, actor models.Actor, organizationID string, teamID string) error {
+	args := m.Called(ctx, actor, organizationID, teamID)
 	return args.Error(0)
 }
 
@@ -187,31 +188,31 @@ type MockOrganizationTeamMemberService struct {
 	mock.Mock
 }
 
-func (m *MockOrganizationTeamMemberService) AddTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error) {
-	args := m.Called(ctx, actorUserID, organizationID, teamID, request)
+func (m *MockOrganizationTeamMemberService) AddTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, request types.AddOrganizationTeamMemberRequest) (*types.OrganizationTeamMember, error) {
+	args := m.Called(ctx, actor, organizationID, teamID, request)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationTeamMember), args.Error(1)
 }
 
-func (m *MockOrganizationTeamMemberService) GetAllTeamMembers(ctx context.Context, actorUserID string, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error) {
-	args := m.Called(ctx, actorUserID, organizationID, teamID, page, limit)
+func (m *MockOrganizationTeamMemberService) GetAllTeamMembers(ctx context.Context, actor models.Actor, organizationID string, teamID string, page int, limit int) ([]types.OrganizationTeamMember, error) {
+	args := m.Called(ctx, actor, organizationID, teamID, page, limit)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]types.OrganizationTeamMember), args.Error(1)
 }
 
-func (m *MockOrganizationTeamMemberService) GetTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error) {
-	args := m.Called(ctx, actorUserID, organizationID, teamID, memberID)
+func (m *MockOrganizationTeamMemberService) GetTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) (*types.OrganizationTeamMember, error) {
+	args := m.Called(ctx, actor, organizationID, teamID, memberID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.OrganizationTeamMember), args.Error(1)
 }
 
-func (m *MockOrganizationTeamMemberService) RemoveTeamMember(ctx context.Context, actorUserID string, organizationID string, teamID string, memberID string) error {
-	args := m.Called(ctx, actorUserID, organizationID, teamID, memberID)
+func (m *MockOrganizationTeamMemberService) RemoveTeamMember(ctx context.Context, actor models.Actor, organizationID string, teamID string, memberID string) error {
+	args := m.Called(ctx, actor, organizationID, teamID, memberID)
 	return args.Error(0)
 }

--- a/plugins/session/hooks.go
+++ b/plugins/session/hooks.go
@@ -58,8 +58,8 @@ func (p *SessionPlugin) signedOutMatcher(reqCtx *models.RequestContext) bool {
 }
 
 func (p *SessionPlugin) validateSessionHook(reqCtx *models.RequestContext) error {
-	// Cooperative auth: if UserID already set by another auth plugin, skip
-	if reqCtx.UserID != nil {
+	// Cooperative auth: If a Principal is already resolved by a previous plugin, skip execution
+	if reqCtx.Actor != nil {
 		return nil
 	}
 
@@ -71,7 +71,6 @@ func (p *SessionPlugin) validateSessionHook(reqCtx *models.RequestContext) error
 	}
 
 	sessionToken := cookie.Value
-
 	hashedToken := p.tokenService.Hash(sessionToken)
 	session, err := p.sessionService.GetByToken(reqCtx.Request.Context(), hashedToken)
 	if err != nil || session == nil {
@@ -86,7 +85,10 @@ func (p *SessionPlugin) validateSessionHook(reqCtx *models.RequestContext) error
 		return nil
 	}
 
-	reqCtx.SetUserIDInContext(session.UserID)
+	reqCtx.SetActorInContext(&models.Actor{
+		ID:   session.UserID,
+		Type: models.ActorUser,
+	})
 	reqCtx.Values[models.ContextSessionID.String()] = session.ID
 
 	// Optionally renew session if it's past 50% of its max age
@@ -98,34 +100,33 @@ func (p *SessionPlugin) validateSessionHook(reqCtx *models.RequestContext) error
 }
 
 func (p *SessionPlugin) validateSessionHookOptional(reqCtx *models.RequestContext) error {
-	// Cooperative auth: if UserID already set by another auth plugin, skip
-	if reqCtx.UserID != nil {
+	// Cooperative auth: If a Principal is already resolved, skip execution
+	if reqCtx.Actor != nil {
 		return nil
 	}
 
 	cookie, err := reqCtx.Request.Cookie(p.globalConfig.Session.CookieName)
 	if err != nil {
-		// No cookie, skip silently
-		return nil
+		return nil // No cookie, skip silently
 	}
 
 	sessionToken := cookie.Value
 	hashedToken := p.tokenService.Hash(sessionToken)
 	session, err := p.sessionService.GetByToken(reqCtx.Request.Context(), hashedToken)
 	if err != nil || session == nil {
-		// Invalid session, skip silently
-		return nil
+		return nil // Invalid session, skip silently
 	}
 
 	if session.ExpiresAt.Before(time.Now().UTC()) {
-		// Expired session, skip silently
-		return nil
+		return nil // Expired session, skip silently
 	}
 
-	reqCtx.SetUserIDInContext(session.UserID)
+	reqCtx.SetActorInContext(&models.Actor{
+		ID:   session.UserID,
+		Type: models.ActorUser,
+	})
 	reqCtx.Values[models.ContextSessionID.String()] = session.ID
 
-	// Optionally renew session if it's past 50% of its max age
 	if p.shouldRenewSession(session) {
 		p.renewSession(reqCtx.ResponseWriter, reqCtx.Request, session)
 	}
@@ -134,7 +135,8 @@ func (p *SessionPlugin) validateSessionHookOptional(reqCtx *models.RequestContex
 }
 
 func (p *SessionPlugin) issueSessionCookieHook(reqCtx *models.RequestContext) error {
-	if reqCtx.UserID == nil {
+	// Check if a principal exists before trying to execute cookie emission
+	if reqCtx.Actor == nil {
 		return nil
 	}
 

--- a/plugins/session/plugin.go
+++ b/plugins/session/plugin.go
@@ -96,7 +96,7 @@ func (p *SessionPlugin) AuthMiddleware() func(http.Handler) http.Handler {
 				p.renewSession(w, r, session)
 			}
 
-			ctx := context.WithValue(r.Context(), models.ContextUserID, session.UserID)
+			ctx := context.WithValue(r.Context(), models.ContextAuthActor, &models.Actor{ID: session.UserID, Type: models.ActorUser, Permissions: []string{}})
 			ctx = context.WithValue(ctx, models.ContextSessionID, session.ID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -113,7 +113,7 @@ func (p *SessionPlugin) OptionalAuthMiddleware() func(http.Handler) http.Handler
 					p.renewSession(w, r, session)
 				}
 
-				ctx := context.WithValue(r.Context(), models.ContextUserID, session.UserID)
+				ctx := context.WithValue(r.Context(), models.ContextAuthActor, &models.Actor{ID: session.UserID, Type: models.ActorUser, Permissions: []string{}})
 				ctx = context.WithValue(ctx, models.ContextSessionID, session.ID)
 				r = r.WithContext(ctx)
 			}

--- a/plugins/totp/handlers/disable_handler.go
+++ b/plugins/totp/handlers/disable_handler.go
@@ -16,8 +16,8 @@ func (h *DisableHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		principal, ok := models.GetActorFromContext(ctx)
+		if !ok || principal == nil || principal.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{
 				"message": "Unauthorized",
 			})
@@ -25,7 +25,7 @@ func (h *DisableHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		if err := h.UseCase.Disable(ctx, userID); err != nil {
+		if err := h.UseCase.Disable(ctx, principal.ID); err != nil {
 			reqCtx.SetJSONResponse(http.StatusBadRequest, map[string]any{
 				"message": err.Error(),
 			})

--- a/plugins/totp/handlers/enable_handler.go
+++ b/plugins/totp/handlers/enable_handler.go
@@ -20,8 +20,8 @@ func (h *EnableHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		principal, ok := models.GetActorFromContext(ctx)
+		if !ok || principal == nil || principal.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{
 				"message": "Unauthorized",
 			})
@@ -29,7 +29,7 @@ func (h *EnableHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		result, err := h.UseCase.Enable(ctx, userID, h.GlobalConfig.AppName)
+		result, err := h.UseCase.Enable(ctx, principal.ID, h.GlobalConfig.AppName)
 		if err != nil {
 			reqCtx.SetJSONResponse(http.StatusBadRequest, map[string]any{
 				"message": err.Error(),

--- a/plugins/totp/handlers/generate_backup_codes_handler.go
+++ b/plugins/totp/handlers/generate_backup_codes_handler.go
@@ -17,8 +17,8 @@ func (h *GenerateBackupCodesHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		principal, ok := models.GetActorFromContext(ctx)
+		if !ok || principal == nil || principal.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{
 				"message": "Unauthorized",
 			})
@@ -26,7 +26,7 @@ func (h *GenerateBackupCodesHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		codes, err := h.UseCase.Generate(ctx, userID)
+		codes, err := h.UseCase.Generate(ctx, principal.ID)
 		if err != nil {
 			reqCtx.SetJSONResponse(http.StatusBadRequest, map[string]any{
 				"message": err.Error(),

--- a/plugins/totp/handlers/get_totp_uri_handler.go
+++ b/plugins/totp/handlers/get_totp_uri_handler.go
@@ -18,8 +18,8 @@ func (h *GetTOTPURIHandler) Handler() http.HandlerFunc {
 		ctx := r.Context()
 		reqCtx, _ := models.GetRequestContext(ctx)
 
-		userID, ok := models.GetUserIDFromContext(ctx)
-		if !ok {
+		principal, ok := models.GetActorFromContext(ctx)
+		if !ok || principal == nil || principal.ID == "" {
 			reqCtx.SetJSONResponse(http.StatusUnauthorized, map[string]any{
 				"message": "Unauthorized",
 			})
@@ -27,7 +27,7 @@ func (h *GetTOTPURIHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		totpURI, err := h.UseCase.GetTOTPURI(ctx, userID, h.GlobalConfig.AppName)
+		totpURI, err := h.UseCase.GetTOTPURI(ctx, principal.ID, h.GlobalConfig.AppName)
 		if err != nil {
 			reqCtx.SetJSONResponse(http.StatusBadRequest, map[string]any{
 				"message": err.Error(),

--- a/plugins/totp/handlers/verify_backup_code_handler.go
+++ b/plugins/totp/handlers/verify_backup_code_handler.go
@@ -55,7 +55,7 @@ func (h *VerifyBackupCodeHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		reqCtx.SetUserIDInContext(result.User.ID)
+		reqCtx.SetActorInContext(&models.Actor{ID: result.User.ID, Type: models.ActorUser})
 		reqCtx.Values[models.ContextSessionID.String()] = result.Session.ID
 		reqCtx.Values[models.ContextSessionToken.String()] = result.SessionToken
 		reqCtx.Values[models.ContextAuthSuccess.String()] = true

--- a/plugins/totp/handlers/verify_totp_handler.go
+++ b/plugins/totp/handlers/verify_totp_handler.go
@@ -55,7 +55,7 @@ func (h *VerifyTOTPHandler) Handler() http.HandlerFunc {
 			return
 		}
 
-		reqCtx.SetUserIDInContext(result.User.ID)
+		reqCtx.SetActorInContext(&models.Actor{ID: result.User.ID, Type: models.ActorUser})
 		reqCtx.Values[models.ContextSessionID.String()] = result.Session.ID
 		reqCtx.Values[models.ContextSessionToken.String()] = result.SessionToken
 		reqCtx.Values[models.ContextAuthSuccess.String()] = true

--- a/plugins/totp/hooks.go
+++ b/plugins/totp/hooks.go
@@ -47,10 +47,10 @@ func (p *TOTPPlugin) interceptSignInHook(reqCtx *models.RequestContext) error {
 		return nil
 	}
 
-	if reqCtx.UserID == nil || *reqCtx.UserID == "" {
+	if reqCtx.Actor == nil || reqCtx.Actor.ID == "" {
 		return nil
 	}
-	userID := *reqCtx.UserID
+	userID := reqCtx.Actor.ID
 
 	enabled, err := p.totpRepo.IsEnabled(ctx, userID)
 	if err != nil {

--- a/plugins/totp/plugin_test.go
+++ b/plugins/totp/plugin_test.go
@@ -209,7 +209,7 @@ func TestInterceptHook(t *testing.T) {
 				Values: map[string]any{
 					models.ContextAuthSuccess.String(): true,
 				},
-				UserID: &userID,
+				Actor: &models.Actor{ID: userID, Type: models.ActorUser, Permissions: []string{}},
 			}
 
 			err := plugin.interceptSignInHook(reqCtx)


### PR DESCRIPTION
This PR refactors how authentication context is propagated and handled across the codebase. We are moving away from a user-centric (human-only) authentication state to a unified **Identity Principal** architecture.

With this change, Authula now natively supports both human users (`user`) and machine-to-machine agents (`machine`, e.g., API keys, service accounts) through a single polymorphic interface. Additionally, this PR introduces first-class **Organization** scoping directly into the core authentication context, establishing a clean, unified foundation for multi-tenancy isolation and downstream access control (RBAC).

### Key Structural Changes

* **Polymorphic Principals:** Replaced scalar `UserID` tracking with a standard `RequestPrincipal` struct containing an explicit identity `ID`, `Type`, and dynamic `Metadata`.
* **Multi-Tenant Scoping:** Embedded `OrganizationID` into the `RequestPrincipal` to streamline tenancy related data and context.
* **Decoupled Hook Lifecycle:** Updated the routing engine and session hooks to check for cooperative principal resolution, ensuring downstream plugins can evaluate access rights identically regardless of whether the caller authenticated via a cookie or an API token.