### PR TITLE
feat: Add Actor model and context handling for authentication

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -248,12 +248,28 @@ func (auth *Auth) GetUserIDFromContext(ctx context.Context) (string, bool) {
 	return models.GetUserIDFromContext(ctx)
 }
 
+// GetActorFromContext retrieves the Actor from a context.
+// Returns the Actor and a boolean indicating whether it was found.
+// This is a convenience wrapper around models.GetActorFromContext to avoid
+// requiring application code to import the models package.
+func (auth *Auth) GetActorFromContext(ctx context.Context) (*models.Actor, bool) {
+	return models.GetActorFromContext(ctx)
+}
+
 // GetUserIDFromRequest retrieves the user ID from an HTTP request's context.
 // Returns the user ID and a boolean indicating whether it was found.
 // This is a convenience wrapper around models.GetUserIDFromRequest to avoid
 // requiring application code to import the models package.
 func (auth *Auth) GetUserIDFromRequest(req *http.Request) (string, bool) {
 	return models.GetUserIDFromRequest(req)
+}
+
+// GetActorFromRequest retrieves the Actor from an HTTP request's context.
+// Returns the Actor and a boolean indicating whether it was found.
+// This is a convenience wrapper around models.GetActorFromRequest to avoid
+// requiring application code to import the models package.
+func (auth *Auth) GetActorFromRequest(req *http.Request) (*models.Actor, bool) {
+	return models.GetActorFromRequest(req)
 }
 
 // Handler returns the HTTP handler that serves all authentication routes and hooks.

--- a/models/actor.go
+++ b/models/actor.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"context"
+	"net/http"
+	"slices"
+)
+
+type ActorType string
+
+const (
+	ActorUser    ActorType = "user"
+	ActorMachine ActorType = "machine"
+)
+
+// Actor represents the fully resolved identity context of the caller.
+type Actor struct {
+	// Represents the unique identifier of the credential/actor.
+	ID string
+
+	// Indicates the type of actor
+	Type ActorType
+
+	// Identifies the tenant a user is actively operating inside an org.
+	// This can be nil if a user is operating in a personal/non-tenant scope.
+	OrganizationID *string
+
+	// Holds the static permissions granted to this specific request credential.
+	Permissions []string
+
+	// Flexible field to attach additional information about the actor.
+	Metadata map[string]any
+}
+
+func (actor *Actor) HasPermission(permission string) bool {
+	if actor == nil || permission == "" {
+		return false
+	}
+
+	return slices.Contains(actor.Permissions, permission)
+}
+
+// SetActorInContext updates the actor in both the RequestContext and the underlying Go context stream.
+func (reqCtx *RequestContext) SetActorInContext(actor *Actor) {
+	reqCtx.Actor = actor
+	if reqCtx.Actor.Permissions == nil {
+		reqCtx.Actor.Permissions = make([]string, 0)
+	}
+	if reqCtx.Actor.Metadata == nil {
+		reqCtx.Actor.Metadata = make(map[string]any)
+	}
+	reqCtx.Request = reqCtx.Request.WithContext(context.WithValue(reqCtx.Request.Context(), ContextAuthActor, actor))
+}
+
+// GetActorFromContext extracts the actor from the Go context or RequestContext fallback.
+func GetActorFromContext(ctx context.Context) (*Actor, bool) {
+	if val := ctx.Value(ContextAuthActor); val != nil {
+		if actor, ok := val.(*Actor); ok {
+			return actor, ok
+		}
+	}
+
+	if reqCtx, ok := GetRequestContext(ctx); ok && reqCtx.Actor != nil {
+		return reqCtx.Actor, true
+	}
+
+	return nil, false
+}
+
+// GetActorFromRequest extracts the actor directly from an incoming HTTP request.
+func GetActorFromRequest(req *http.Request) (*Actor, bool) {
+	return GetActorFromContext(req.Context())
+}

--- a/models/context.go
+++ b/models/context.go
@@ -10,6 +10,7 @@ type ContextKey string
 
 const (
 	ContextUserID                       ContextKey = "user_id"
+	ContextAuthActor                    ContextKey = "auth.actor"
 	ContextSessionID                    ContextKey = "session_id"
 	ContextSessionToken                 ContextKey = "session_token"
 	ContextRequestContext               ContextKey = "request_context"
@@ -37,7 +38,9 @@ type RequestContext struct {
 	Headers http.Header
 
 	// User information (may be nil if not authenticated)
-	UserID   *string
+	UserID *string
+	// Actor identity resolved by authentication, may be nil if unauthenticated
+	Actor    *Actor
 	ClientIP string
 
 	// Generic key-value storage for hooks to share data
@@ -78,6 +81,14 @@ func SetRequestContext(ctx context.Context, rc *RequestContext) context.Context 
 func GetRequestContext(ctx context.Context) (*RequestContext, bool) {
 	rc, ok := ctx.Value(ContextRequestContext).(*RequestContext)
 	return rc, ok
+}
+
+// GetOrganizationIDFromContext extracts the active tenant ID from the context if it exists.
+func GetOrganizationIDFromContext(ctx context.Context) (string, bool) {
+	if actor, ok := GetActorFromContext(ctx); ok && actor.OrganizationID != nil {
+		return *actor.OrganizationID, true
+	}
+	return "", false
 }
 
 // SetResponse sets the captured response fields that will be written once


### PR DESCRIPTION
Added a new Actor model to the request context for the authentication state as Authula will start to support multiple identities such as: Users, API keys and machine-to-machine tokens.

This is a very small PR to introduce the Actor model only. Therefore, future PRs will be refactoring the codebase to migrate away from the user-centric approach to this new multi-identity approach.