### PR TITLE
chore: support injecting custom logger

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -18,7 +18,10 @@ import (
 
 // InitLogger initializes the logger based on configuration
 func InitLogger(config *models.Config) models.Logger {
-	return internalbootstrap.InitLogger(internalbootstrap.LoggerOptions{Level: config.Logger.Level})
+	return internalbootstrap.InitLogger(internalbootstrap.LoggerOptions{
+		Level:  config.Logger.Level,
+		Logger: config.Logger.Logger,
+	})
 }
 
 // InitDatabase creates a Bun DB connection based on provider

--- a/config/options.go
+++ b/config/options.go
@@ -158,6 +158,9 @@ func WithLogger(config models.LoggerConfig) ConfigOption {
 		if config.Level != "" {
 			c.Logger.Level = config.Level
 		}
+		if config.Logger != nil {
+			c.Logger.Logger = config.Logger
+		}
 	}
 }
 

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/Authula/authula/models"
+)
+
+type customLogger struct{}
+
+func (l *customLogger) Debug(msg string, args ...any) {}
+func (l *customLogger) Info(msg string, args ...any)  {}
+func (l *customLogger) Warn(msg string, args ...any)  {}
+func (l *customLogger) Error(msg string, args ...any) {}
+
+func TestWithLoggerConfiguresLevelAndCustomLogger(t *testing.T) {
+	logger := &customLogger{}
+
+	config := NewConfig(WithLogger(models.LoggerConfig{
+		Level:  "debug",
+		Logger: logger,
+	}))
+
+	if config.Logger.Level != "debug" {
+		t.Fatalf("expected logger level debug, got %q", config.Logger.Level)
+	}
+
+	if config.Logger.Logger != logger {
+		t.Fatal("expected custom logger to be configured")
+	}
+}

--- a/internal/bootstrap/logger.go
+++ b/internal/bootstrap/logger.go
@@ -12,11 +12,16 @@ import (
 
 // LoggerOptions configures logger initialization
 type LoggerOptions struct {
-	Level string
+	Level  string
+	Logger models.Logger
 }
 
 // InitLogger creates a configured logger instance
 func InitLogger(opts LoggerOptions) models.Logger {
+	if opts.Logger != nil {
+		return opts.Logger
+	}
+
 	environment := os.Getenv(env.EnvGoEnvironment)
 	var logger *slog.Logger
 

--- a/internal/bootstrap/logger_test.go
+++ b/internal/bootstrap/logger_test.go
@@ -1,0 +1,18 @@
+package bootstrap
+
+import "testing"
+
+type customLogger struct{}
+
+func (l *customLogger) Debug(msg string, args ...any) {}
+func (l *customLogger) Info(msg string, args ...any)  {}
+func (l *customLogger) Warn(msg string, args ...any)  {}
+func (l *customLogger) Error(msg string, args ...any) {}
+
+func TestInitLoggerUsesConfiguredLogger(t *testing.T) {
+	logger := &customLogger{}
+
+	if got := InitLogger(LoggerOptions{Level: "debug", Logger: logger}); got != logger {
+		t.Fatal("expected configured logger to be used")
+	}
+}

--- a/models/config.go
+++ b/models/config.go
@@ -43,7 +43,8 @@ type DatabaseConfig struct {
 }
 
 type LoggerConfig struct {
-	Level string `json:"level" toml:"level"`
+	Level  string `json:"level" toml:"level"`
+	Logger Logger `json:"-" toml:"-"`
 }
 
 type SessionConfig struct {


### PR DESCRIPTION
Adds support for injecting a custom logger and uses it in bootstrap setup.

- Thread custom logger through `models.LoggerConfig` and `WithLogger` options.
- Update bootstrap init to pass optional logger through to `InitLogger`.
- Return a provided logger from `InitLogger` when set.
- Add focused tests for option wiring and logger override behavior.

Closes #71
